### PR TITLE
Changes to address issues and support NetworkServer integration

### DIFF
--- a/Quality.xcodeproj/project.pbxproj
+++ b/Quality.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0177D9D329F0986700703F3C /* NetworkServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0177D9D229F0986700703F3C /* NetworkServer.swift */; };
 		1221F3F9280F10A3003E8B77 /* SimplyCoreAudio in Frameworks */ = {isa = PBXBuildFile; productRef = 1221F3F8280F10A3003E8B77 /* SimplyCoreAudio */; };
 		1221F3FB280F1EEF003E8B77 /* OutputDevices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1221F3FA280F1EEF003E8B77 /* OutputDevices.swift */; };
 		1234F508281E8372007EC9F5 /* PrivateMediaRemote in Frameworks */ = {isa = PBXBuildFile; productRef = 1234F507281E8372007EC9F5 /* PrivateMediaRemote */; };
@@ -29,6 +30,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0177D9D229F0986700703F3C /* NetworkServer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkServer.swift; sourceTree = "<group>"; };
 		1221F3FA280F1EEF003E8B77 /* OutputDevices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputDevices.swift; sourceTree = "<group>"; };
 		1234F509281E83D1007EC9F5 /* MediaRemote.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MediaRemote.framework; path = ../../../../../System/Library/PrivateFrameworks/MediaRemote.framework; sourceTree = "<group>"; };
 		1234F50D281E8F07007EC9F5 /* MediaTrack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTrack.swift; sourceTree = "<group>"; };
@@ -94,6 +96,7 @@
 			isa = PBXGroup;
 			children = (
 				1254A79D2814024300241107 /* Info.plist */,
+				0177D9D229F0986700703F3C /* NetworkServer.swift */,
 				12AFF5C02811AD40001CC6ED /* AppDelegate.swift */,
 				1272AA97280DBB4900FD72BA /* QualityApp.swift */,
 				1272AA99280DBB4900FD72BA /* ContentView.swift */,
@@ -213,6 +216,7 @@
 				1234F510281E9520007EC9F5 /* MediaRemoteController.swift in Sources */,
 				1272AA9A280DBB4900FD72BA /* ContentView.swift in Sources */,
 				1293436B28131591002E19A8 /* CurrentUser.swift in Sources */,
+				0177D9D329F0986700703F3C /* NetworkServer.swift in Sources */,
 				1272AA98280DBB4900FD72BA /* QualityApp.swift in Sources */,
 				127C972D281FCF000087313B /* AppVersion.swift in Sources */,
 			);
@@ -344,7 +348,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_ASSET_PATHS = "\"Quality/Preview Content\"";
-				DEVELOPMENT_TEAM = 3X69W4AQD6;
+				DEVELOPMENT_TEAM = 3RTN3G859Z;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -378,7 +382,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_ASSET_PATHS = "\"Quality/Preview Content\"";
-				DEVELOPMENT_TEAM = 3X69W4AQD6;
+				DEVELOPMENT_TEAM = 3RTN3G859Z;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/Quality.xcodeproj/project.pbxproj
+++ b/Quality.xcodeproj/project.pbxproj
@@ -346,7 +346,7 @@
 				CODE_SIGN_ENTITLEMENTS = Quality/Quality.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Quality/Preview Content\"";
 				DEVELOPMENT_TEAM = 3RTN3G859Z;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -360,7 +360,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.4;
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.vincent-neo.LosslessSwitcher";
 				PRODUCT_NAME = LosslessSwitcher;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -380,7 +380,7 @@
 				CODE_SIGN_ENTITLEMENTS = Quality/Quality.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Quality/Preview Content\"";
 				DEVELOPMENT_TEAM = 3RTN3G859Z;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -394,7 +394,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.4;
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.vincent-neo.LosslessSwitcher";
 				PRODUCT_NAME = LosslessSwitcher;
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Quality/AppDelegate.swift
+++ b/Quality/AppDelegate.swift
@@ -264,6 +264,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
     
+    func updateBitDepthDetectionMenuItemState() {
+        if let menu = statusItem?.menu,
+           let enableBitDepthDetectionItem = menu.item(withTitle: "Bit Depth Detection") {
+            enableBitDepthDetectionItem.state = outputDevices.enableBitDepthDetection ? .on : .off
+        }
+    }
+    
     func updateClients() {
         if let networkServer = self.networkServer {
             networkServer.updateClients()

--- a/Quality/AppDelegate.swift
+++ b/Quality/AppDelegate.swift
@@ -18,10 +18,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var outputDevices: OutputDevices!
     private let defaults = Defaults.shared
     private var mrController: MediaRemoteController!
+    private var networkServer: NetworkServer!
     private var devicesMenu: NSMenu!
+    private var rateMenu: NSMenu!
+    private var bitDepthMenu: NSMenu!
     
     var statusItem: NSStatusItem?
     var cancellable: AnyCancellable?
+    private var refreshedSampleRatesAndBitDepths: AnyCancellable?
 
     private var _statusItemTitle = "Loading..."
     var statusItemTitle: String {
@@ -58,6 +62,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         AppDelegate.instance = self
         outputDevices = OutputDevices()
         mrController = MediaRemoteController(outputDevices: outputDevices)
+        networkServer = NetworkServer(outputDevices)
         
         checkPermissions()
         
@@ -72,18 +77,37 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         menu.addItem(NSMenuItem.separator())
         
-        let showSampleRateItem = NSMenuItem(title: defaults.statusBarItemTitle, action: #selector(toggleSampleRate(item:)), keyEquivalent: "")
-        menu.addItem(showSampleRateItem)
+        let setSampleRateItem = NSMenuItem(title: "Set Current to Detected", action: #selector(setCurrentToDetected), keyEquivalent: "")
+        menu.addItem(setSampleRateItem)
         
-        let enableBitDepthItem = NSMenuItem(title: "Bit Depth Switching", action: #selector(toggleBitDepthDetection(item:)), keyEquivalent: "")
+        let enableAutoSwitchItem = NSMenuItem(title: "Auto Switching", action: #selector(toggleAutoSwitching(item:)), keyEquivalent: "")
+        menu.addItem(enableAutoSwitchItem)
+        enableAutoSwitchItem.state = defaults.userPreferAutoSwitch ? .on : .off
+     
+        let enableBitDepthItem = NSMenuItem(title: "Bit Depth Detection", action: #selector(toggleBitDepthDetection(item:)), keyEquivalent: "")
         menu.addItem(enableBitDepthItem)
         enableBitDepthItem.state = defaults.userPreferBitDepthDetection ? .on : .off
+        
+        let setRateItem = NSMenuItem(title: "Set Rate", action: nil, keyEquivalent: "")
+        self.rateMenu = NSMenu()
+        setRateItem.submenu = self.rateMenu
+        menu.addItem(setRateItem)
+        self.handleRateMenu()
+        
+        let setBitDepthItem = NSMenuItem(title: "Set Bit Depth", action: nil, keyEquivalent: "")
+        self.bitDepthMenu = NSMenu()
+        setBitDepthItem.submenu = self.bitDepthMenu
+        menu.addItem(setBitDepthItem)
+        self.handleBitDepthMenu()
         
         let selectedDeviceItem = NSMenuItem(title: "Selected Device", action: nil, keyEquivalent: "")
         self.devicesMenu = NSMenu()
         selectedDeviceItem.submenu = self.devicesMenu
         menu.addItem(selectedDeviceItem)
         self.handleDevicesMenu()
+        
+        let showSampleRateItem = NSMenuItem(title: defaults.statusBarItemTitle, action: #selector(toggleSampleRate(item:)), keyEquivalent: "")
+        menu.addItem(showSampleRateItem)
         
         menu.addItem(NSMenuItem.separator())
         
@@ -107,7 +131,41 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         cancellable = NotificationCenter.default.publisher(for: .deviceListChanged).sink(receiveValue: { _ in
             self.handleDevicesMenu()
         })
-
+       
+        refreshedSampleRatesAndBitDepths = NotificationCenter.default.publisher(for: .refreshedSampleRatesAndBitDepths).sink(receiveValue: { _ in
+            self.handleRateMenu()
+            self.handleBitDepthMenu()
+        })
+        
+        networkServer.startListener()
+    }
+    
+    func handleRateMenu() {
+        self.rateMenu.removeAllItems()
+        var idx = 0
+        for rate in outputDevices.sampleRatesForCurrentBitDepth {
+            //let rateTitle = "\(rate.mSampleRate / 1000) kHz - \(rate.mBitsPerChannel) bit"
+            let rateTitle = "\(rate.mSampleRate / 1000) kHz"
+            let rateItem = NSMenuItem(title: rateTitle, action: #selector(sampleRateSelected(_:)), keyEquivalent: "")
+            rateItem.tag = idx
+            rateItem.target = self
+            self.rateMenu.addItem(rateItem)
+            idx += 1
+        }
+    }
+    
+    func handleBitDepthMenu() {
+        self.bitDepthMenu.removeAllItems()
+        var idx = 0
+        for format in outputDevices.bitDepthsForCurrentSampleRate {
+            //let formatTitle = "\(format.mBitsPerChannel) bit - \(format.mSampleRate / 1000) kHz"
+            let formatTitle = "\(format.mBitsPerChannel) bit"
+            let formatItem = NSMenuItem(title: formatTitle, action: #selector(formatSelected(_:)), keyEquivalent: "")
+            formatItem.tag = idx
+            formatItem.target = self
+            self.bitDepthMenu.addItem(formatItem)
+            idx += 1
+        }
     }
     
     func handleDevicesMenu() {
@@ -173,6 +231,48 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             await defaults.setPreferBitDepthDetection(newValue: !defaults.userPreferBitDepthDetection)
             item.state = defaults.userPreferBitDepthDetection ? .on : .off
         }
+    }
+    
+    @objc func toggleAutoSwitching(item: NSMenuItem) {
+        Task {
+            await defaults.setPreferAutoSwitch(newValue: !defaults.userPreferAutoSwitch)
+            item.state = defaults.userPreferAutoSwitch ? .on : .off
+        }
+    }
+    
+    @objc func setCurrentToDetected() {
+        outputDevices.setCurrentToDetected()
+    }
+    
+    
+    @objc func sampleRateSelected(_ sender: NSMenuItem) {
+        let selectedIndex = sender.tag
+        let selectedRate = outputDevices.sampleRatesForCurrentBitDepth[selectedIndex]
+        outputDevices.manualSetFormat(selectedRate)
+    }
+    
+    @objc func formatSelected(_ sender: NSMenuItem) {
+        let selectedIndex = sender.tag
+        let selectedFormat = outputDevices.bitDepthsForCurrentSampleRate[selectedIndex]
+        outputDevices.manualSetFormat(selectedFormat)
+    }
+    
+    func updateAutoSwitchingMenuItemState() {
+        if let menu = statusItem?.menu,
+           let enableAutoSwitchItem = menu.item(withTitle: "Auto Switching") {
+            enableAutoSwitchItem.state = outputDevices.enableAutoSwitch ? .on : .off
+        }
+    }
+    
+    func updateClients() {
+        if let networkServer = self.networkServer {
+            networkServer.updateClients()
+        }
+    }
+
+    deinit {
+        cancellable?.cancel()
+        refreshedSampleRatesAndBitDepths?.cancel()
     }
     
 }

--- a/Quality/ContentView.swift
+++ b/Quality/ContentView.swift
@@ -12,13 +12,30 @@ import SimplyCoreAudio
 struct ContentView: View {
     @EnvironmentObject var outputDevices: OutputDevices
     
+    private var formattedCurrentSettings: String {
+        let currentSampleRate = outputDevices.currentSampleRate ?? 1
+        let currentBitDepth = outputDevices.currentBitDepth ?? 0
+        return  "C: \(outputDevices.kHzString(currentSampleRate))kHz \(currentBitDepth)bit"
+    }
+    
+    private var formattedDetectedSettings: String {
+        let detectedSampleRate = outputDevices.detectedSampleRate ?? 1
+        let detectedBitDepth = outputDevices.detectedBitDepth ?? 0
+        var formattedSettings = "D: \(outputDevices.kHzString(detectedSampleRate))kHz"
+        if outputDevices.enableBitDepthDetection {
+            formattedSettings += " \(detectedBitDepth)bit"
+        }
+        return formattedSettings
+    }
+    
     var body: some View {
         VStack {
-            if let currentSampleRate = outputDevices.currentSampleRate {
-                let formattedSampleRate = String(format: "%.1f kHz", currentSampleRate)
-                Text(formattedSampleRate)
-                    .font(.system(size: 23, weight: .semibold, design: .default))
-            }
+            Text(formattedCurrentSettings)
+                .font(.system(size: 23, weight: .semibold, design: .default))
+                .lineLimit(1)
+            Text(formattedDetectedSettings)
+                .font(.system(size: 23, weight: .semibold, design: .default))
+                .lineLimit(1)
             if let device = outputDevices.selectedOutputDevice ?? outputDevices.defaultOutputDevice {
                 Text(device.name)
                     .font(.system(size: 14.5, weight: .regular, design: .default))

--- a/Quality/Defaults.swift
+++ b/Quality/Defaults.swift
@@ -9,17 +9,23 @@ import Foundation
 
 class Defaults: ObservableObject {
     static let shared = Defaults()
+    @Published var userPreferBitDepthDetection: Bool
+    @Published var userPreferAutoSwitch: Bool
+    
     private let kUserPreferIconStatusBarItem = "com.vincent-neo.LosslessSwitcher-Key-UserPreferIconStatusBarItem"
     private let kSelectedDeviceUID = "com.vincent-neo.LosslessSwitcher-Key-SelectedDeviceUID"
     private let kUserPreferBitDepthDetection = "com.vincent-neo.LosslessSwitcher-Key-BitDepthDetection"
+    private let kUserPreferAutoSwitch = "com.vincent-neo.LosslessSwitcher-Key-AutoSwitch"
     
     private init() {
         UserDefaults.standard.register(defaults: [
             kUserPreferIconStatusBarItem : true,
-            kUserPreferBitDepthDetection : false
+            kUserPreferBitDepthDetection : false,
+            kUserPreferAutoSwitch : true
         ])
         
         self.userPreferBitDepthDetection = UserDefaults.standard.bool(forKey: kUserPreferBitDepthDetection)
+        self.userPreferAutoSwitch = UserDefaults.standard.bool(forKey: kUserPreferAutoSwitch)
     }
     
     var userPreferIconStatusBarItem: Bool {
@@ -40,16 +46,19 @@ class Defaults: ObservableObject {
         }
     }
     
-    @Published var userPreferBitDepthDetection: Bool
-    
-    
     @MainActor func setPreferBitDepthDetection(newValue: Bool) {
         UserDefaults.standard.set(newValue, forKey: kUserPreferBitDepthDetection)
         self.userPreferBitDepthDetection = newValue
+    }
+    
+    @MainActor func setPreferAutoSwitch(newValue: Bool) {
+        UserDefaults.standard.set(newValue, forKey: kUserPreferAutoSwitch)
+        self.userPreferAutoSwitch = newValue
     }
 
     var statusBarItemTitle: String {
         let title = self.userPreferIconStatusBarItem ? "Show Sample Rate" : "Show Icon"
         return title
     }
+    
 }

--- a/Quality/NetworkServer.swift
+++ b/Quality/NetworkServer.swift
@@ -1,0 +1,232 @@
+//
+//  NetworkServer.swift
+//  LosslessSwitcher
+//
+//  Created by Kris Roberts on 4/7/23.
+//
+
+import Foundation
+import Network
+import SystemConfiguration
+
+class NetworkServer {
+    var outputDevices: OutputDevices
+
+    private let defaults = Defaults.shared
+    private let hostName = (SCDynamicStoreCopyComputerName(nil, nil) as String?) ?? "Unknown"
+    private var listener: NWListener?
+    private var clientConnections: [NWConnection] = []
+    
+    init(_ outputDevices: OutputDevices) {
+        self.outputDevices = outputDevices
+    }
+    
+    func startListener() {
+        let txtRecordData: [String: String] = ["serverHostName": hostName]
+        let txtRecord = NWTXTRecord(txtRecordData)
+
+        let tcpParameters = NWParameters.tcp
+        let endpointPort = NWEndpoint.Port.any
+        
+        do {
+            listener = try NWListener(using: tcpParameters, on: endpointPort)
+        } catch {
+            print("Failed to create listener: \(error)")
+            return
+        }
+        
+        listener?.service = NWListener.Service(name: "lossless-switcher", type: "_lossless-switcher._tcp", domain: "local", txtRecord: txtRecord)
+
+        listener?.stateUpdateHandler = { newState in
+            switch newState {
+            case .ready:
+                print("Listener ready")
+            case .failed(let error):
+                print("Listener failed with error: \(error)")
+            default:
+                break
+            }
+        }
+        
+        listener?.newConnectionHandler = { newConnection in
+            newConnection.start(queue: .main)
+            newConnection.stateUpdateHandler = { newState in
+                // Check if the connection already exists in the array
+                if !self.clientConnections.contains(where: { $0 === newConnection }) {
+                    // Add the new connection to the clientConnections array if it doesn't already exist
+                    self.clientConnections.append(newConnection)
+                }
+                switch newState {
+                case .ready:
+                    //self.lastConnection = newConnection
+                    self.receiveClientMessage(connection: newConnection)
+                default:
+                    break
+                }
+            }
+        }
+        
+        listener?.start(queue: .main)
+    }
+    
+    func receiveClientMessage(connection: NWConnection) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { data, _, _, error in
+            if let data = data {
+                do {
+                    let clientMessage = try JSONDecoder().decode(ClientMessage.self, from: data)
+                    print("Received: \(clientMessage)")
+                    self.processClientMessage(clientMessage, connection: connection)
+                } catch {
+                    print("Error decoding ClientMessage: \(error)")
+                }
+            } else if let error = error {
+                print("Error receiving ClientMessage: \(error)")
+            }
+        }
+    }
+
+    func processClientMessage(_ clientMessage: ClientMessage, connection: NWConnection) {
+        switch clientMessage.request {
+        case .refresh:
+            self.sendServerResponse(self.getResponseData(), connection: connection)
+            break
+        case .toggleAutoSwitching:
+            Task {
+                await MainActor.run {
+                    defaults.setPreferAutoSwitch(newValue: !defaults.userPreferAutoSwitch)
+                    AppDelegate.instance.updateAutoSwitchingMenuItemState()
+                }
+            }
+            break
+        case .setDeviceSampleRate(let sampleRate):
+            outputDevices.setDeviceSampleRate(sampleRate)
+            break
+        }
+        
+        // Call receiveClientMessage(connection:) again to continue listening for messages
+        self.receiveClientMessage(connection: connection)
+
+    }
+    
+    func getResponseData() -> ServerResponse {
+        let response = ServerResponse(
+            currentSampleRate: (self.outputDevices.currentSampleRate ?? 1) / 1000,
+            detectedSampleRate: (self.outputDevices.detectedSampleRate ?? 1) / 1000,
+            autoSwitchingEnabled: self.outputDevices.enableAutoSwitch,
+            supportedSampleRates: self.outputDevices.supportedSampleRates,
+            defaultOutputDeviceName: self.outputDevices.defaultOutputDevice?.name ?? "Unknown Output Device",
+            serverHostName: self.hostName
+        )
+        return response
+    }
+    
+    // Add a function to clean up inactive connections
+    func cleanupInactiveConnections() {
+        clientConnections.removeAll { connection in
+            connection.state != .ready
+        }
+    }
+    
+    func updateClients() {
+        // Call cleanupInactiveConnections to remove connections that are not in .ready state
+        cleanupInactiveConnections()
+
+        // Iterate through the client connections and send updates to any that are .ready
+        for connection in clientConnections {
+            if connection.state == .ready {
+                sendServerResponse(getResponseData(), connection: connection)
+            }
+        }
+    }
+    
+    func sendServerResponse(_ response: ServerResponse, connection: NWConnection) {
+        do {
+            let data = try JSONEncoder().encode(response)
+            print("Sending: \(response)")
+            connection.send(content: data, completion: .contentProcessed({ error in
+                if let error = error {
+                    print("Error sending ServerResponse: \(error)")
+                } else {
+                    print("ServerResponse sent")
+                }
+            }))
+        } catch {
+            print("Error encoding ServerResponse: \(error)")
+        }
+    }
+    
+}
+
+struct ServerResponse: Codable, CustomStringConvertible {
+    let currentSampleRate: Float64
+    let detectedSampleRate: Float64
+    let autoSwitchingEnabled: Bool
+    let supportedSampleRates: [Float64] 
+    let defaultOutputDeviceName: String
+    let serverHostName: String
+    
+    var description: String {
+        return "ServerResponse(currentSampleRate: \(currentSampleRate), detectedSampleRate: \(detectedSampleRate), autoSwitchingEnabled: \(autoSwitchingEnabled), serverHostName: \(serverHostName), defaultOutputDeviceName: \(defaultOutputDeviceName), supportedSampleRates: \(supportedSampleRates))"
+    }
+}
+
+enum ClientRequest: Codable, CustomStringConvertible {
+    case refresh
+    case toggleAutoSwitching
+    case setDeviceSampleRate(Float64)
+    
+    var description: String {
+        switch self {
+        case .refresh:
+            return "ClientRequest.refresh"
+        case .toggleAutoSwitching:
+            return "ClientRequest.toggleAutoSwitching"
+        case .setDeviceSampleRate(let sampleRate):
+            return "ClientRequest.setDeviceSampleRate(\(sampleRate))"
+        }
+    }
+    
+    private enum CodingKeys: CodingKey {
+        case type
+        case sampleRate
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+        
+        switch type {
+        case "refresh":
+            self = .refresh
+        case "toggleAutoSwitching":
+            self = .toggleAutoSwitching
+        case "setDeviceSampleRate":
+            let sampleRate = try container.decode(Float64.self, forKey: .sampleRate)
+            self = .setDeviceSampleRate(sampleRate)
+        default:
+            throw DecodingError.dataCorruptedError(forKey: .type, in: container, debugDescription: "Invalid request type")
+        }
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        
+        switch self {
+        case .refresh:
+            try container.encode("refresh", forKey: .type)
+        case .toggleAutoSwitching:
+            try container.encode("toggleAutoSwitching", forKey: .type)
+        case .setDeviceSampleRate(let sampleRate):
+            try container.encode("setDeviceSampleRate", forKey: .type)
+            try container.encode(sampleRate, forKey: .sampleRate)
+        }
+    }
+}
+
+struct ClientMessage: Codable, CustomStringConvertible {
+    let request: ClientRequest
+    
+    var description: String {
+        return "ClientMessage(request: \(request))"
+    }
+}

--- a/Quality/NetworkServer.swift
+++ b/Quality/NetworkServer.swift
@@ -1,6 +1,6 @@
 //
 //  NetworkServer.swift
-//  LosslessSwitcher
+//  LosslessSwitcherNetworkServer
 //
 //  Created by Kris Roberts on 4/7/23.
 //
@@ -8,6 +8,7 @@
 import Foundation
 import Network
 import SystemConfiguration
+import CoreAudioTypes
 
 class NetworkServer {
     var outputDevices: OutputDevices
@@ -31,7 +32,7 @@ class NetworkServer {
         do {
             listener = try NWListener(using: tcpParameters, on: endpointPort)
         } catch {
-            print("Failed to create listener: \(error)")
+            print("startListener: Failed to create listener: \(error) \(timeStamp())")
             return
         }
         
@@ -40,9 +41,9 @@ class NetworkServer {
         listener?.stateUpdateHandler = { newState in
             switch newState {
             case .ready:
-                print("Listener ready")
+                print("stateUpdateHandler: Listener ready \(self.timeStamp())")
             case .failed(let error):
-                print("Listener failed with error: \(error)")
+                print("stateUpdateHandler: Listener failed with error: \(error) \(self.timeStamp())")
             default:
                 break
             }
@@ -54,33 +55,58 @@ class NetworkServer {
                 // Check if the connection already exists in the array
                 if !self.clientConnections.contains(where: { $0 === newConnection }) {
                     // Add the new connection to the clientConnections array if it doesn't already exist
+                    //print("newConnection: Adding connection: \(newConnection.endpoint) \(self.timeStamp())")
                     self.clientConnections.append(newConnection)
                 }
                 switch newState {
                 case .ready:
-                    //self.lastConnection = newConnection
+                    //print("newConnection: .ready: \(newConnection.state) \(newConnection.endpoint) \(self.timeStamp())")
                     self.receiveClientMessage(connection: newConnection)
                 default:
+                    //handle failre cases by closing connection?
+                    //print("newConnection: default: \(newConnection.state) \(newConnection.endpoint) \(self.timeStamp())")
                     break
                 }
             }
         }
-        
         listener?.start(queue: .main)
     }
     
     func receiveClientMessage(connection: NWConnection) {
-        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { data, _, _, error in
+        connection.receive(minimumIncompleteLength: 4, maximumLength: 4) { data, _, _, error in
+            if let data = data, data.count == 4 {
+                let length = data.withUnsafeBytes { $0.load(as: UInt32.self) }.bigEndian
+                print("receiveClientMessage: New request, length: \(length) bytes")
+                self.receiveData(connection: connection, totalLength: Int(length), receivedLength: 0, receivedData: Data())
+            } else if let error = error {
+                print("Error receiving cient request length: \(error) \(self.timeStamp())")
+            }
+        }
+    }
+    
+    func receiveData(connection: NWConnection, totalLength: Int, receivedLength: Int, receivedData: Data) {
+        let remainingLength = totalLength - receivedLength
+        let chunkSize = min(connection.maximumDatagramSize, remainingLength)
+
+        connection.receive(minimumIncompleteLength: chunkSize, maximumLength: chunkSize) { data, _, _, error in
             if let data = data {
-                do {
-                    let clientMessage = try JSONDecoder().decode(ClientMessage.self, from: data)
-                    print("Received: \(clientMessage)")
-                    self.processClientMessage(clientMessage, connection: connection)
-                } catch {
-                    print("Error decoding ClientMessage: \(error)")
+                let newReceivedData = receivedData + data
+                let newReceivedLength = receivedLength + data.count
+
+                if newReceivedLength == totalLength {
+                    do {
+                        let clientMessage = try JSONDecoder().decode(ClientMessage.self, from: newReceivedData)
+                        print("receiveData: received/decoded: \(clientMessage.description)")
+                        self.processClientMessage(clientMessage, connection: connection)
+                    } catch {
+                        print("Error decoding client message data: \(error) \(self.timeStamp())")
+                    }
+                } else {
+                    // Keep receiving data until we have the complete message
+                    self.receiveData(connection: connection, totalLength: totalLength, receivedLength: newReceivedLength, receivedData: newReceivedData)
                 }
             } else if let error = error {
-                print("Error receiving ClientMessage: \(error)")
+                print("Error receiving client message data: \(error) \(self.timeStamp())")
             }
         }
     }
@@ -98,32 +124,70 @@ class NetworkServer {
                 }
             }
             break
-        case .setDeviceSampleRate(let sampleRate):
-            outputDevices.setDeviceSampleRate(sampleRate)
+        case .toggleBitDepthDetection:
+            Task {
+                await MainActor.run {
+                    defaults.setPreferBitDepthDetection(newValue: !defaults.userPreferBitDepthDetection)
+                    AppDelegate.instance.updateBitDepthDetectionMenuItemState()
+                }
+            }
+            break
+        case .setDeviceSampleRate(let asbdRate):
+            let formatSampleRate = asbdRate.audioStreamBasicDescription
+            outputDevices.manualSetFormat(formatSampleRate)
+            break
+        case .setDeviceBitDepth(let asbdBits):
+            let formatBitDepth = asbdBits.audioStreamBasicDescription
+            outputDevices.manualSetFormat(formatBitDepth)
+            break
+        case .setCurrentToDetected:
+            outputDevices.setCurrentToDetected()
             break
         }
         
         // Call receiveClientMessage(connection:) again to continue listening for messages
         self.receiveClientMessage(connection: connection)
-
     }
     
     func getResponseData() -> ServerResponse {
         let response = ServerResponse(
-            currentSampleRate: (self.outputDevices.currentSampleRate ?? 1) / 1000,
-            detectedSampleRate: (self.outputDevices.detectedSampleRate ?? 1) / 1000,
+            currentSampleRate: self.outputDevices.currentSampleRate ?? 1,
+            currentBitDepth: self.outputDevices.currentBitDepth ?? 0,
+            detectedSampleRate: self.outputDevices.detectedSampleRate ?? 1,
+            detectedBitDepth: self.outputDevices.detectedBitDepth ?? 0,
             autoSwitchingEnabled: self.outputDevices.enableAutoSwitch,
-            supportedSampleRates: self.outputDevices.supportedSampleRates,
+            bitDepthDetectionEnabled: self.outputDevices.enableBitDepthDetection,
+            sampleRatesForCurrentBitDepth: self.outputDevices.sampleRatesForCurrentBitDepth.map { CodableAudioStreamBasicDescription(from: $0)},
+            bitDepthsForCurrentSampleRate: self.outputDevices.bitDepthsForCurrentSampleRate.map { CodableAudioStreamBasicDescription(from: $0)},
             defaultOutputDeviceName: self.outputDevices.defaultOutputDevice?.name ?? "Unknown Output Device",
-            serverHostName: self.hostName
+            serverHostName: self.hostName,
+            timeStamp: self.timeStamp()
         )
         return response
     }
     
-    // Add a function to clean up inactive connections
+    func timeStamp() -> String {
+        let currentDate = Date()
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+        return dateFormatter.string(from: currentDate)
+    }
+    
     func cleanupInactiveConnections() {
         clientConnections.removeAll { connection in
-            connection.state != .ready
+            switch connection.state {
+            case .failed(_):
+                //print("Closing connection due to failure: \(connection.debugDescription)")
+                connection.cancel()
+                return true
+            case .cancelled:
+                //print("Closing connection due to cancellation: \(connection.debugDescription)")
+                connection.cancel()
+                return true
+            default:
+                //print("cleanupInactiveConnections: Leaving \(connection.state) - \(connection.endpoint)")
+                return false
+            }
         }
     }
     
@@ -134,6 +198,7 @@ class NetworkServer {
         // Iterate through the client connections and send updates to any that are .ready
         for connection in clientConnections {
             if connection.state == .ready {
+                //print("updateClients: About to send to: \(connection.endpoint) \(timeStamp())")
                 sendServerResponse(getResponseData(), connection: connection)
             }
         }
@@ -142,38 +207,105 @@ class NetworkServer {
     func sendServerResponse(_ response: ServerResponse, connection: NWConnection) {
         do {
             let data = try JSONEncoder().encode(response)
-            print("Sending: \(response)")
-            connection.send(content: data, completion: .contentProcessed({ error in
+            let dataLength = UInt32(data.count)
+            let lengthData = withUnsafeBytes(of: dataLength.bigEndian) { Data($0) }
+            let combinedData = lengthData + data
+            connection.send(content: combinedData, completion: .contentProcessed({ error in
                 if let error = error {
-                    print("Error sending ServerResponse: \(error)")
+                    print("sendServerResponse: Error sending: \(error) \(self.timeStamp())")
                 } else {
-                    print("ServerResponse sent")
+                    print("sendServerResponse: Sent - Data size: \(data.count) bytes, MTU: \(connection.maximumDatagramSize)")
+                    print(" \(response.description)")
                 }
             }))
         } catch {
             print("Error encoding ServerResponse: \(error)")
+            print(response.description)
         }
     }
-    
 }
 
 struct ServerResponse: Codable, CustomStringConvertible {
     let currentSampleRate: Float64
+    let currentBitDepth: UInt32
     let detectedSampleRate: Float64
+    let detectedBitDepth: UInt32
     let autoSwitchingEnabled: Bool
-    let supportedSampleRates: [Float64] 
+    let bitDepthDetectionEnabled: Bool
+    let sampleRatesForCurrentBitDepth: [CodableAudioStreamBasicDescription]
+    let bitDepthsForCurrentSampleRate: [CodableAudioStreamBasicDescription]
     let defaultOutputDeviceName: String
     let serverHostName: String
+    let timeStamp: String
     
     var description: String {
-        return "ServerResponse(currentSampleRate: \(currentSampleRate), detectedSampleRate: \(detectedSampleRate), autoSwitchingEnabled: \(autoSwitchingEnabled), serverHostName: \(serverHostName), defaultOutputDeviceName: \(defaultOutputDeviceName), supportedSampleRates: \(supportedSampleRates))"
+        return "ServerResponse(currentSampleRate: \(currentSampleRate), detectedSampleRate: \(detectedSampleRate), autoSwitchingEnabled: \(autoSwitchingEnabled), serverHostName: \(serverHostName), defaultOutputDeviceName: \(defaultOutputDeviceName), timeStamp: \(timeStamp)\n SR4BD: \(sampleRatesForCurrentBitDepth)\n BD4SR: \(bitDepthsForCurrentSampleRate)"
+    }
+}
+
+struct CodableAudioStreamBasicDescription: Codable, Equatable, CustomStringConvertible {
+    let mSampleRate: Float64
+    let mFormatID: UInt32
+    let mFormatFlags: UInt32
+    let mBytesPerPacket: UInt32
+    let mFramesPerPacket: UInt32
+    let mBytesPerFrame: UInt32
+    let mChannelsPerFrame: UInt32
+    let mBitsPerChannel: UInt32
+    let mReserved: UInt32
+    
+    init(from audioStreamBasicDescription: AudioStreamBasicDescription) {
+        mSampleRate = audioStreamBasicDescription.mSampleRate
+        mFormatID = audioStreamBasicDescription.mFormatID
+        mFormatFlags = audioStreamBasicDescription.mFormatFlags
+        mBytesPerPacket = audioStreamBasicDescription.mBytesPerPacket
+        mFramesPerPacket = audioStreamBasicDescription.mFramesPerPacket
+        mBytesPerFrame = audioStreamBasicDescription.mBytesPerFrame
+        mChannelsPerFrame = audioStreamBasicDescription.mChannelsPerFrame
+        mBitsPerChannel = audioStreamBasicDescription.mBitsPerChannel
+        mReserved = audioStreamBasicDescription.mReserved
+    }
+    
+    static func ==(lhs: CodableAudioStreamBasicDescription, rhs: CodableAudioStreamBasicDescription) -> Bool {
+        return lhs.mSampleRate == rhs.mSampleRate &&
+               lhs.mFormatID == rhs.mFormatID &&
+               lhs.mFormatFlags == rhs.mFormatFlags &&
+               lhs.mBytesPerPacket == rhs.mBytesPerPacket &&
+               lhs.mFramesPerPacket == rhs.mFramesPerPacket &&
+               lhs.mBytesPerFrame == rhs.mBytesPerFrame &&
+               lhs.mChannelsPerFrame == rhs.mChannelsPerFrame &&
+               lhs.mBitsPerChannel == rhs.mBitsPerChannel &&
+               lhs.mReserved == rhs.mReserved
+    }
+    
+    var description: String {
+        return String(format: "%.1fkHz/%dbit ", mSampleRate, mBitsPerChannel)
+    }
+}
+
+extension CodableAudioStreamBasicDescription {
+    var audioStreamBasicDescription: AudioStreamBasicDescription {
+        return AudioStreamBasicDescription(
+            mSampleRate: self.mSampleRate,
+            mFormatID: self.mFormatID,
+            mFormatFlags: self.mFormatFlags,
+            mBytesPerPacket: self.mBytesPerPacket,
+            mFramesPerPacket: self.mFramesPerPacket,
+            mBytesPerFrame: self.mBytesPerFrame,
+            mChannelsPerFrame: self.mChannelsPerFrame,
+            mBitsPerChannel: self.mBitsPerChannel,
+            mReserved: self.mReserved
+        )
     }
 }
 
 enum ClientRequest: Codable, CustomStringConvertible {
     case refresh
     case toggleAutoSwitching
-    case setDeviceSampleRate(Float64)
+    case toggleBitDepthDetection
+    case setDeviceSampleRate(CodableAudioStreamBasicDescription)
+    case setDeviceBitDepth(CodableAudioStreamBasicDescription)
+    case setCurrentToDetected
     
     var description: String {
         switch self {
@@ -181,14 +313,21 @@ enum ClientRequest: Codable, CustomStringConvertible {
             return "ClientRequest.refresh"
         case .toggleAutoSwitching:
             return "ClientRequest.toggleAutoSwitching"
-        case .setDeviceSampleRate(let sampleRate):
-            return "ClientRequest.setDeviceSampleRate(\(sampleRate))"
+        case .toggleBitDepthDetection:
+            return "ClientRequest.toggleBitDepthDetection"
+        case .setDeviceSampleRate(let asbdRate):
+            return "ClientRequest.setDeviceSampleRate(\(asbdRate.mSampleRate))"
+        case .setDeviceBitDepth(let asbdBits):
+            return "ClientRequest.setDeviceBitDepth(\(asbdBits.mBitsPerChannel))"
+        case .setCurrentToDetected:
+            return "ClientRequest.setCurentToDetected"
         }
     }
     
     private enum CodingKeys: CodingKey {
         case type
         case sampleRate
+        case bitDepth
     }
     
     init(from decoder: Decoder) throws {
@@ -200,9 +339,16 @@ enum ClientRequest: Codable, CustomStringConvertible {
             self = .refresh
         case "toggleAutoSwitching":
             self = .toggleAutoSwitching
+        case "toggleBitDepthDetection":
+            self = .toggleBitDepthDetection
         case "setDeviceSampleRate":
-            let sampleRate = try container.decode(Float64.self, forKey: .sampleRate)
-            self = .setDeviceSampleRate(sampleRate)
+            let asbdRate = try container.decode(CodableAudioStreamBasicDescription.self, forKey: .sampleRate)
+            self = .setDeviceSampleRate(asbdRate)
+        case "setDeviceBitDepth":
+            let asbdBits = try container.decode(CodableAudioStreamBasicDescription.self, forKey: .bitDepth)
+            self = .setDeviceBitDepth(asbdBits)
+        case "setCurrentToDetected":
+            self = .setCurrentToDetected
         default:
             throw DecodingError.dataCorruptedError(forKey: .type, in: container, debugDescription: "Invalid request type")
         }
@@ -216,17 +362,25 @@ enum ClientRequest: Codable, CustomStringConvertible {
             try container.encode("refresh", forKey: .type)
         case .toggleAutoSwitching:
             try container.encode("toggleAutoSwitching", forKey: .type)
-        case .setDeviceSampleRate(let sampleRate):
+        case .toggleBitDepthDetection:
+            try container.encode("toggleBitDepthDetection", forKey: .type)
+        case .setDeviceSampleRate(let asbdRate):
             try container.encode("setDeviceSampleRate", forKey: .type)
-            try container.encode(sampleRate, forKey: .sampleRate)
+            try container.encode(asbdRate, forKey: .sampleRate)
+        case .setDeviceBitDepth(let asbdBits):
+            try container.encode("setDeviceBitDepth", forKey: .type)
+            try container.encode(asbdBits, forKey: .bitDepth)
+        case .setCurrentToDetected:
+            try container.encode("setCurrentToDetected", forKey: .type)
         }
     }
 }
 
 struct ClientMessage: Codable, CustomStringConvertible {
     let request: ClientRequest
+    let timeStamp: String
     
     var description: String {
-        return "ClientMessage(request: \(request))"
+        return "ClientMessage(request: \(request)), timeStamp: \(timeStamp)"
     }
 }

--- a/Quality/OutputDevices.swift
+++ b/Quality/OutputDevices.swift
@@ -154,9 +154,15 @@ class OutputDevices: ObservableObject {
         do {
             let musicLogs = try Console.getRecentEntries(type: .music)
             let coreAudioLogs = try Console.getRecentEntries(type: .coreAudio)
+            let coreMediaLogs = try Console.getRecentEntries(type: .coreMedia)
             
             allStats.append(contentsOf: CMPlayerParser.parseMusicConsoleLogs(musicLogs))
-            allStats.append(contentsOf: CMPlayerParser.parseCoreAudioConsoleLogs(coreAudioLogs))
+            if enableBitDepthDetection {
+                allStats.append(contentsOf: CMPlayerParser.parseCoreAudioConsoleLogs(coreAudioLogs))
+            }
+            else {
+                allStats.append(contentsOf: CMPlayerParser.parseCoreMediaConsoleLogs(coreMediaLogs))
+            }
             
             allStats.sort(by: {$0.priority > $1.priority})
             print("[getAllStats] \(allStats)")

--- a/README.md
+++ b/README.md
@@ -4,21 +4,38 @@
 </p>
 
 #  
+This is a fork of the LosslessSwitcher project:
+https://github.com/vincentneo/LosslessSwitcher
 
-LosslessSwitcher switches your current audio device's sample rate to match the currently playing lossless song on your Apple Music app, automatically.
+The version here presetns a Bonjour network listener and allows clients to connect for remote control.  The iOS companion app LosslessSwitcherRemote can be found here:
+https://github.com/Robertsmania/LosslessSwitcherRemote
 
-Let's say if the next song that you are playing, is a Hi-Res Lossless track with a sample rate of 192kHz, LosslessSwitcher will switch your device to that sample rate as soon as possible. 
+In addition to the network support, this version of the macOS LosslessSwitcher has a few functional changes as well:
+Both the Current (C:) and Detected (D:) frequencies are shown in the menubar and dropdown.
+The menu has a new option to "Set Rate to Detected".
+A toggle option for "Auto switching" is also shown.
 
-The opposite happens, when the next track happens to have a lower sample rate. 
+<img width="252" alt="app screenshot, with new display elements for Current and Detected frequencies, Set Rate to Current and Auto Swithing toggle" src="https://user-images.githubusercontent.com/11642124/231385169-37cf4e14-ae31-4cdb-87bb-5fb66aaa263b.png">
 
 ## Installation
-Simply go to the Releases page of this repository. [(Link to latest release)](https://github.com/vincentneo/LosslessSwitcher/releases/latest)
+Simply go to the Releases page of this repository. [(Link to latest release)](https://github.com/robertsmania/LosslessSwitcher/releases/latest)
+
+### Alternatively, try the beta! [(link)](https://github.com/robertsmania/LosslessSwitcher/releases/)
 
 Drag the app to your Applications folder. If you wish to have it running when logging in, you should be able to add LosslessSwitcher in System Preferences:
 
 ```
 > User & Groups > Login Items > Add LosslessSwitcher app
 ``` 
+
+Below is the README from the source project:
+-----
+
+LosslessSwitcher switches your current audio device's sample rate to match the currently playing lossless song on your Apple Music app, automatically.
+
+Let's say if the next song that you are playing, is a Hi-Res Lossless track with a sample rate of 192kHz, LosslessSwitcher will switch your device to that sample rate as soon as possible. 
+
+The opposite happens, when the next track happens to have a lower sample rate. 
 
 ## App details
 
@@ -57,17 +74,49 @@ Other than that, it should run on any Mac running macOS 11.4 or later.
 By using LosslessSwitcher, you agree that under no circumstances will the developer or any contributors be held responsible or liable in any way for any claims, damages, losses, expenses, costs or liabilities whatsoever or any other consequences suffered by you or incurred by you directly or indirectly in connection with any form of usages of LosslessSwitcher.
 
 ## Devices tested
-I did not test on any Macs running macOS 11, ~~or any Apple Silicon based Macs (I don't have one 😢)~~  Use at your own risk.
 
-UPDATE: A [reddit user](https://www.reddit.com/r/audiophile/comments/t6l3pb/comment/i69v5fe/?utm_source=share&utm_medium=web2x&context=3) has updated to me that LosslessSwitcher is working on Apple Silicon Macs! Thanks!
+Here are some device combinations tested to be working, by users of LosslessSwitcher.
+Regardless, you are still reminded to use LosslessSwitcher at your own risk.
 
-| Mac Model | macOS Version | Audio Device |
-| -------------------------- | --------------- | ------------ |
-| Mac Mini (2018)            | 12.2            | Denon PMA-50 |
-| MacBook Pro 13 inch (2018) | 12.3.1          | Denon PMA-50 |
+| CPU             | Mac Model                                            | macOS Version   | Beta macOS? | Audio Device    |
+| --------------- | ---------------------------------------------------- | --------------- | ----------- | --------------- |
+|      Intel      | MacBook Pro 13 inch (Early 2015, Dual Core i5)       | 11.6.2          | No    | Denon AVR-X4400H |
+|      Intel      | Mac mini (2018)                                      | 12.2<br/>12.4   | No    | Denon PMA-50    |
+|      Intel      | MacBook Pro 13 inch (2018)                           | 12.3.1          | No    | Denon PMA-50    |
+|      Intel      | MacBook Pro 13 inch, four Thunderbolt 3 ports (2016) | 12.3.1          | No    | Topping DX7 Pro |
+|  Apple Silicon  | MacBook Pro 13 inch (M1, 2020)                       | 12.3.1          | No    | FX Audio DAC-X6 |
+|      Intel      | MacBook Pro 15 inch (2016)                           | 12.4            | No    | Topping D30Pro  |
+|  Apple Silicon  | Mac mini (M1, 2020)                                  | 12.4            | No    | Meridian Explorer 2 |
+|      Intel      | Hackintosh (XPS 9570, i7-8750H)                      | 12.4            | No    | Universal Audio Apollo X4<br/>FiiO Q3<br/>FiiO M5 (DAC mode) |
+|      Intel      | MacBook Pro 13 inch (2016)                           | 12.4<br/>12.6.1 | No    | AudioQuest Dragonfly Cobalt  |
+|  Apple Silicon  | Mac mini (M1, 2020)                                  | 12.4            | No    | iFi Zen DAC V2  |
+|      Intel      | MacBook Pro 15 inch (2018)                           | 12.4            | No    | PS Audio Sprout |
+|  Apple Silicon  | MacBook Air 13 inch (2020)                           | 12.5.1          | No    | Shanling M8 |
+|  Apple Silicon  | Mac Studio (M1 Max, 2022)                            | 12.6            | No    | Focusrite Scarlett 18i8 (2nd Gen) | 
+|      Intel      | MacBook Pro 16 inch (2019)                           | 12.6            | No    | Mytek Brooklyn+ DAC |
+|  Apple Silicon  | Mac mini (M1, 2020)                                  | 13.0            | 22A5286j | Topping D50s    |
+|  Apple Silicon  | Mac mini (M1, 2020)                                  | 13.0            | No    | iBasso DC06<br/>Khadass Tone 2 Pro |
+|  Apple Silicon  | MacBook Pro 14 inch (M1 Pro, 2021)                   | 13.0<br/>13.0.1 | No    | Topping D10 Balanced |
+|  Apple Silicon  | Mac mini (M1, 2020)                                  | 13.0.1          | No    | Fiio K7<br/>Fiio K5 Pro (AKM DAC)<br/>Topping EX5 |
+|  Apple Silicon  | MacBook Pro 14 inch (2021)                           | 13.0.1          | No    | AudioQuest Dragonfly Black v1.5 |
+|  Apple Silicon  | MacBook Air (M1, 2020)                               | 13.1            | No    | Schiit Bifrost 2 |
+|      Intel      | MacBook Pro 15 inch (2018)                           | 13.1            | No    | Apogee Groove |
+|  Apple Silicon  | iMac 24 inch (M1, 2021)                              | 13.1            | No    | SMSL PO100 |
+|  Apple Silicon  | MacBook Pro 14 inch (2021)                           | 13.1            | No    | Chord Mojo |
+|  Apple Silicon  | Mac mini (M1, 2020)                                  | 13.2            | No    | RME ADI-2 DAC FS |
+|  Apple Silicon  | MacBook Pro 16" (M1 Max, 2021)                       | 13.2            | No    | M-Audio Fast Track |
+|  Apple Silicon  | Mac Studio (M1 Max, 2022)                            | 13.2.1          | No    | RME ADI-2 PRO FS R (Black Edition) |
+|      Intel      | 27-inch iMac (2017)                                  | 13.2.1          | No    | Chord Hugo M Scaler + TT2 Combo |
+|  Apple Silicon  | Mac mini (M1, 2020)                                  | 13.2.1          | No    | Moondrop Moonriver 2 |
+
+You can add to this list by modifying this README and opening a new pull request!
 
 ## License
 LosslessSwitcher is licensed under GPL-3.0.
+
+## Love the idea of this?
+If you appreciate the development of this application, feel free to spread the word around so more people get to know about LosslessSwitcher. 
+You can also show your support by [sponsoring](https://github.com/sponsors/vincentneo) this project!
 
 ## Dependencies
 - [Sweep](https://github.com/JohnSundell/Sweep), by @JohnSundell, a easy to use Swift `String` scanner.


### PR DESCRIPTION
NetworkServer - establishes a bonjour listener and accepts connections from iOS clients running the companion iOS app LosslessSwitcherRemote:
https://github.com/Robertsmania/LosslessSwitcherRemote

That may understandably be too much to consider pulling into the main LosslessSwitcher project.  But other changes address these issues and can be taken individually:

Show both current and detected in menu bar and dropdown #89
https://github.com/vincentneo/LosslessSwitcher/issues/89

Manual set current to detected #88
https://github.com/vincentneo/LosslessSwitcher/issues/88

Setting to toggle auto-switch #87
https://github.com/vincentneo/LosslessSwitcher/issues/87

Display Bit Depth in addition to Sample Rate #86
https://github.com/vincentneo/LosslessSwitcher/issues/86

Manual bit depth override in menu - already in 44

Build 14 still switches Bit Depth when disabled #79
https://github.com/vincentneo/LosslessSwitcher/issues/79

Manual sample rate override in menu #44
https://github.com/vincentneo/LosslessSwitcher/issues/44

Bit depth not changing #2
https://github.com/vincentneo/LosslessSwitcher/issues/2

