### PR TITLE
Update Devices tested list

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Regardless, you are still reminded to use LosslessSwitcher at your own risk.
 |      Intel      | 27-inch iMac (2017)                                  | 13.2.1          | No    | Chord Hugo M Scaler + TT2 Combo |
 |  Apple Silicon  | Mac mini (M1, 2020)                                  | 13.2.1          | No    | Moondrop Moonriver 2 |
 |  Apple Silicon  | MacBook Pro 13 inch (M1, 2020)                       | 13.3.1          | No    | Gustard X18 |            
+|      Intel      | 27-inch iMac (Late 2014)                             | 13.3.1 (a)      | No    | SMSL M500 |
 
 You can add to this list by modifying this README and opening a new pull request!
 


### PR DESCRIPTION
Add SMSL M500 to tested devices list, successfully playing 96 kHz Hi-Res Audio from Apple Music

Running latest macOS 13.3.1 (a) on older iMac using OCLP

PS: Adding bit depth display to the UI would be nice