### PR TITLE
do less unnecessary work when bit-depth switching

### DIFF
--- a/Quality/CMPlayerStuff.swift
+++ b/Quality/CMPlayerStuff.swift
@@ -26,6 +26,11 @@ class CMPlayerParser {
         var stats = [CMPlayerStats]()
         
         for entry in entries {
+            // ignore useless log messages for faster swithcing
+            if !entry.message.contains("audioCapabilities:") {
+                continue
+            }
+            
             let date = entry.date
             let rawMessage = entry.message
             

--- a/Quality/OutputDevices.swift
+++ b/Quality/OutputDevices.swift
@@ -238,7 +238,9 @@ class OutputDevices: ObservableObject {
     func setFormats(device: AudioDevice?, format: AudioStreamBasicDescription?) {
         guard let device, let format else { return }
         let streams = device.streams(scope: .output)
-        streams?.first?.physicalFormat = format
+        if streams?.first?.physicalFormat != format {
+            streams?.first?.physicalFormat = format
+        }
     }
     
     func updateSampleRate(_ sampleRate: Float64) {


### PR DESCRIPTION
I just tested the beta release and found the same issue described in https://github.com/vincentneo/LosslessSwitcher/issues/97 so this hopefully fixes it. I realised that release have been cut from the improvements-1 branch, thus this fix targets that branch.

Fixes most of the issues from #97 which I also encountered with bit-depth switching enabled.

The main issue was that changing `physicalFormat` even when "changing" to the same value causes the same hangs as switching the first time (when a real switch happens).

Also I think the bit-depth should be displayed in the menu of the application if bit-depth switching is enabled, however UI changes are not my expertise!