### PR TITLE
Readme: Updated list of Test devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,11 @@ Regardless, you are still reminded to use LosslessSwitcher at your own risk.
 ### Version 2.x
 | CPU             | Mac Model                                            | macOS Version      | Beta macOS? | Audio Device                       | Version    |
 | --------------- | ---------------------------------------------------- | ------------------ | ----------- | -----------------------------------|------------|
-|  Apple Silicon  | MacBook Pro M1 13 inch (2020)                        | 15.5               | No          | Cambridge Audio CXA81              | 2.0 Beta 1 | 
+|  Apple Silicon  | MacBook Pro 13 inch (M1, 2020)                       | 15.4.1             | No          | Cambridge Audio CXA81              | 2.0 Beta 1 | 
 |  Apple Silicon  | Mac Studio (M1 Max, 2022)                            | 15.4.1             | No          | Denon PMA-150H                     | 2.0 Beta 1 |
+|  Apple Silicon  | MacBook Pro 13 inch (M1, 2020)                       | 15.5               | No          | Cambridge Audio CXA81              | 2.0 Beta 2 | 
 |  Apple Silicon  | MacBook Pro 14 inch (M1 Max, 2021)                   | 15.5               | No          | Cambridge Audio DacMagic 200M      | 2.0 Beta 2 |
+|  Apple Silicon  | MacBook Pro 14 inch (M4 Pro, 2024)                   | 15.5               | No          | Cambridge Audio CXA81              | 2.0 Beta 2 |
 
 You can add to this list by modifying this README and opening a new pull request!
 


### PR DESCRIPTION
Added test devices for v2.0:
- MacBook M1 2020
- MacBook M4 2024
- Cambridge Audio CXA81