### PR TITLE
Next chapter: version 3

### DIFF
--- a/Quality.xcodeproj/project.pbxproj
+++ b/Quality.xcodeproj/project.pbxproj
@@ -31,6 +31,11 @@
 		BF342D7D2E0937D20032F398 /* MediaRemoteAdapter in Embed Frameworks */ = {isa = PBXBuildFile; productRef = BF342D7B2E0935980032F398 /* MediaRemoteAdapter */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		BF342D802E0947890032F398 /* SampleRateLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF342D7F2E0947890032F398 /* SampleRateLabel.swift */; };
 		BF342D822E0948730032F398 /* MenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF342D812E0948730032F398 /* MenuView.swift */; };
+		BF503DEE2F542CA600C361E6 /* LogReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF503DED2F542CA300C361E6 /* LogReader.swift */; };
+		BF503DF22F5442D100C361E6 /* CMEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF503DF12F5442CF00C361E6 /* CMEntry.swift */; };
+		BF503DF42F54646C00C361E6 /* InfoPair.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF503DF32F54644000C361E6 /* InfoPair.swift */; };
+		BF503DF72F5464DB00C361E6 /* OrderedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = BF503DF62F5464DB00C361E6 /* OrderedCollections */; };
+		BF503DF92F54680700C361E6 /* AudioFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF503DF82F54680400C361E6 /* AudioFormat.swift */; };
 		BF5A87BA2E01D746002033D6 /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF5A87B92E01D746002033D6 /* MenuBarController.swift */; };
 		BF7E0D09296336DA009FFEEC /* AudioStreamBasicDescription+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7E0D08296336DA009FFEEC /* AudioStreamBasicDescription+Equatable.swift */; };
 /* End PBXBuildFile section */
@@ -72,6 +77,10 @@
 		BF0C90C92B20C163002F99C9 /* ScriptableApplicationCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptableApplicationCommand.swift; sourceTree = "<group>"; };
 		BF342D7F2E0947890032F398 /* SampleRateLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleRateLabel.swift; sourceTree = "<group>"; };
 		BF342D812E0948730032F398 /* MenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuView.swift; sourceTree = "<group>"; };
+		BF503DED2F542CA300C361E6 /* LogReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogReader.swift; sourceTree = "<group>"; };
+		BF503DF12F5442CF00C361E6 /* CMEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMEntry.swift; sourceTree = "<group>"; };
+		BF503DF32F54644000C361E6 /* InfoPair.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoPair.swift; sourceTree = "<group>"; };
+		BF503DF82F54680400C361E6 /* AudioFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioFormat.swift; sourceTree = "<group>"; };
 		BF5A87B92E01D746002033D6 /* MenuBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarController.swift; sourceTree = "<group>"; };
 		BF7E0D08296336DA009FFEEC /* AudioStreamBasicDescription+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AudioStreamBasicDescription+Equatable.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -83,6 +92,7 @@
 			files = (
 				1221F3F9280F10A3003E8B77 /* SimplyCoreAudio in Frameworks */,
 				1272AAB1280DC71B00FD72BA /* Sweep in Frameworks */,
+				BF503DF72F5464DB00C361E6 /* OrderedCollections in Frameworks */,
 				1234F50A281E83D1007EC9F5 /* MediaRemote.framework in Frameworks */,
 				BF342D7C2E0935980032F398 /* MediaRemoteAdapter in Frameworks */,
 				1234F508281E8372007EC9F5 /* PrivateMediaRemote in Frameworks */,
@@ -120,6 +130,10 @@
 		1272AA96280DBB4900FD72BA /* Quality */ = {
 			isa = PBXGroup;
 			children = (
+				BF503DF82F54680400C361E6 /* AudioFormat.swift */,
+				BF503DF32F54644000C361E6 /* InfoPair.swift */,
+				BF503DF12F5442CF00C361E6 /* CMEntry.swift */,
+				BF503DED2F542CA300C361E6 /* LogReader.swift */,
 				1254A79D2814024300241107 /* Info.plist */,
 				12AFF5C02811AD40001CC6ED /* AppDelegate.swift */,
 				1272AA97280DBB4900FD72BA /* QualityApp.swift */,
@@ -176,6 +190,7 @@
 				1221F3F8280F10A3003E8B77 /* SimplyCoreAudio */,
 				1234F507281E8372007EC9F5 /* PrivateMediaRemote */,
 				BF342D7B2E0935980032F398 /* MediaRemoteAdapter */,
+				BF503DF62F5464DB00C361E6 /* OrderedCollections */,
 			);
 			productName = Quality;
 			productReference = 1272AA94280DBB4900FD72BA /* LosslessSwitcher.app */;
@@ -210,6 +225,7 @@
 				1221F3F7280F10A3003E8B77 /* XCRemoteSwiftPackageReference "SimplyCoreAudio" */,
 				1234F504281E8372007EC9F5 /* XCRemoteSwiftPackageReference "MediaRemote" */,
 				BF342D7A2E0935980032F398 /* XCRemoteSwiftPackageReference "mediaremote-adapter" */,
+				BF503DF52F5464DB00C361E6 /* XCRemoteSwiftPackageReference "swift-collections" */,
 			);
 			productRefGroup = 1272AA95280DBB4900FD72BA /* Products */;
 			projectDirPath = "";
@@ -246,15 +262,19 @@
 				1234F50E281E8F07007EC9F5 /* MediaTrack.swift in Sources */,
 				12F1AA572868639A006C1AD8 /* DeviceMenuItem.swift in Sources */,
 				BF342D822E0948730032F398 /* MenuView.swift in Sources */,
+				BF503DF22F5442D100C361E6 /* CMEntry.swift in Sources */,
 				1221F3FB280F1EEF003E8B77 /* OutputDevices.swift in Sources */,
 				1272AAAE280DC68A00FD72BA /* CMPlayerStuff.swift in Sources */,
 				1272AAAC280DC5E900FD72BA /* Console.swift in Sources */,
+				BF503DEE2F542CA600C361E6 /* LogReader.swift in Sources */,
+				BF503DF92F54680700C361E6 /* AudioFormat.swift in Sources */,
 				1234F510281E9520007EC9F5 /* MediaRemoteController.swift in Sources */,
 				1272AA9A280DBB4900FD72BA /* ContentView.swift in Sources */,
 				1293436B28131591002E19A8 /* CurrentUser.swift in Sources */,
 				1272AA98280DBB4900FD72BA /* QualityApp.swift in Sources */,
 				BF342D802E0947890032F398 /* SampleRateLabel.swift in Sources */,
 				127C972D281FCF000087313B /* AppVersion.swift in Sources */,
+				BF503DF42F54646C00C361E6 /* InfoPair.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -382,7 +402,7 @@
 				CODE_SIGN_ENTITLEMENTS = Quality/Quality.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 24;
+				CURRENT_PROJECT_VERSION = 25;
 				DEVELOPMENT_ASSET_PATHS = "\"Quality/Preview Content\"";
 				DEVELOPMENT_TEAM = 3X69W4AQD6;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -398,7 +418,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 2.0;
+				MARKETING_VERSION = 3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.vincent-neo.LosslessSwitcher";
 				PRODUCT_NAME = LosslessSwitcher;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -418,7 +438,7 @@
 				CODE_SIGN_ENTITLEMENTS = Quality/Quality.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 24;
+				CURRENT_PROJECT_VERSION = 25;
 				DEVELOPMENT_ASSET_PATHS = "\"Quality/Preview Content\"";
 				DEVELOPMENT_TEAM = 3X69W4AQD6;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -434,7 +454,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 2.0;
+				MARKETING_VERSION = 3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.vincent-neo.LosslessSwitcher";
 				PRODUCT_NAME = LosslessSwitcher;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -502,6 +522,14 @@
 				kind = branch;
 			};
 		};
+		BF503DF52F5464DB00C361E6 /* XCRemoteSwiftPackageReference "swift-collections" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-collections.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.3.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -524,6 +552,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = BF342D7A2E0935980032F398 /* XCRemoteSwiftPackageReference "mediaremote-adapter" */;
 			productName = MediaRemoteAdapter;
+		};
+		BF503DF62F5464DB00C361E6 /* OrderedCollections */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BF503DF52F5464DB00C361E6 /* XCRemoteSwiftPackageReference "swift-collections" */;
+			productName = OrderedCollections;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Quality.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Quality.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "365d4d094399ef2f380af176e0b927a21023201306ca8a0aba3d681544ffb930",
+  "originHash" : "54228da2743eebbf59e879ecf51b132657e584b0c7d72d739c5a7c4768d70589",
   "pins" : [
     {
       "identity" : "mediaremote",
@@ -53,6 +53,15 @@
       "state" : {
         "revision" : "3e95ba32cd1b4c877f6163e8eea54afc4e63bf9f",
         "version" : "0.0.3"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
+        "version" : "1.3.0"
       }
     }
   ],

--- a/Quality/AudioFormat.swift
+++ b/Quality/AudioFormat.swift
@@ -1,0 +1,13 @@
+//
+//  AudioFormat.swift
+//  LosslessSwitcher
+//
+//  Created by Vincent Neo on 1/3/26.
+//
+
+import Foundation
+
+struct AudioFormat {
+    let sampleRate: Int
+    let bitDepth: Int?
+}

--- a/Quality/CMEntry.swift
+++ b/Quality/CMEntry.swift
@@ -1,0 +1,15 @@
+//
+//  CMEntry.swift
+//  LosslessSwitcher
+//
+//  Created by Vincent Neo on 1/3/26.
+//
+
+import Foundation
+
+struct CMEntry {
+    let date: Date
+    let trackName: String?
+    let bitDepth: Int?
+    let sampleRate: Int
+}

--- a/Quality/CMPlayerStuff.swift
+++ b/Quality/CMPlayerStuff.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import OSLog
+//import OSLog
 import Sweep
 
 struct CMPlayerStats {

--- a/Quality/Console.swift
+++ b/Quality/Console.swift
@@ -6,7 +6,7 @@
 //
 // https://developer.apple.com/forums/thread/677068
 
-import OSLog
+//import OSLog
 import Cocoa
 
 struct SimpleConsole {
@@ -26,17 +26,18 @@ enum EntryType: String {
 
 class Console {
     static func getRecentEntries(type: EntryType) throws -> [SimpleConsole] {
-        var messages = [SimpleConsole]()
-        let store = try OSLogStore.local()
-        let duration = store.position(timeIntervalSinceEnd: -5.0)
-        let entries = try store.getEntries(with: [], at: duration, matching: type.predicate)
-        // for some reason AnySequence to Array turns it into a empty array?
-        for entry in entries {
-            let consoleMessage = SimpleConsole(date: entry.date, message: entry.composedMessage)
-            //print((date: entry.date, message: entry.composedMessage))
-            messages.append(consoleMessage)
-        }
-        
-        return messages.reversed()
+//        var messages = [SimpleConsole]()
+//        let store = try OSLogStore.local()
+//        let duration = store.position(timeIntervalSinceEnd: -5.0)
+//        let entries = try store.getEntries(with: [], at: duration, matching: type.predicate)
+//        // for some reason AnySequence to Array turns it into a empty array?
+//        for entry in entries {
+//            let consoleMessage = SimpleConsole(date: entry.date, message: entry.composedMessage)
+//            //print((date: entry.date, message: entry.composedMessage))
+//            messages.append(consoleMessage)
+//        }
+//        
+//        return messages.reversed()
+        return []
     }
 }

--- a/Quality/ContentView.swift
+++ b/Quality/ContentView.swift
@@ -6,7 +6,7 @@
 //
 
 import SwiftUI
-import OSLog
+//import OSLog
 import SimplyCoreAudio
 
 struct ContentView: View {

--- a/Quality/InfoPair.swift
+++ b/Quality/InfoPair.swift
@@ -1,0 +1,27 @@
+//
+//  InfoPair.swift
+//  LosslessSwitcher
+//
+//  Created by Vincent Neo on 1/3/26.
+//
+
+import Foundation
+
+class InfoPair: CustomStringConvertible {
+    var track: DatedPair<MediaTrack>?
+    var format: DatedPair<AudioFormat>?
+    
+    init(track: DatedPair<MediaTrack>? = nil, format: DatedPair<AudioFormat>? = nil) {
+        self.track = track
+        self.format = format
+    }
+    
+    var description: String {
+        return "InfoPair(\(String(describing: track)), \(String(describing: format)))"
+    }
+}
+
+struct DatedPair<T> {
+    let date: Date
+    let object: T
+}

--- a/Quality/LogReader.swift
+++ b/Quality/LogReader.swift
@@ -1,0 +1,135 @@
+//
+//  LogReader.swift
+//  LosslessSwitcher
+//
+//  Created by Vincent Neo on 1/3/26.
+//
+
+import Foundation
+import Combine
+import Sweep
+
+class LogReader {
+    
+    let entryStream = PassthroughSubject<CMEntry, Never>()
+    
+    private var process: Process?
+    private let dateFormatter: DateFormatter
+    
+    init() {
+        let dateFormatter = DateFormatter()
+        dateFormatter.timeZone = .autoupdatingCurrent
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+        self.dateFormatter = dateFormatter
+    }
+    
+    func spawnProcessIfNeeded() {
+        guard process == nil else { return }
+        self.spawnProcess()
+    }
+    
+    private func spawnProcess() {
+        let process = Process()
+        self.process = process
+        
+        process.executableURL = URL(filePath: "/usr/bin/log")
+        process.arguments = [
+            "stream",
+            "--style",
+            "compact",
+            "--no-backtrace",
+            "--predicate",
+            "process = \"Music\" AND category=\"ampplay\""
+        ]
+        
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        
+        pipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty else {
+                handle.readabilityHandler = nil
+                return
+            }
+            
+            guard let line = String(data: data, encoding: .utf8) else { return }
+            self?.processLine(line)
+        }
+        
+        do {
+            try process.run()
+        }
+        catch {
+            print("ProcessErr \(error)")
+        }
+    }
+    
+    private func processLine(_ line: String) {
+//        print("\n\nLINE: ", line)
+        guard let dateSubstring = line.firstSubstring(between: .start, and: " Df ") else { return }
+        guard let messageContentSubstring = line.firstSubstring(between: "[com.apple.Music:ampplay] play> cm>> " , and: .end) else { return }
+        let dateString = String(dateSubstring)
+        let message = String(messageContentSubstring)
+        let date = dateFormatter.date(from: dateString)
+        
+        let split = message.split(separator: ",")
+        var trackName: String?
+        var isLossless: Bool?
+        var bitDepth: Int?
+        var sampleRate: Int?
+        
+        for element in split {
+            
+            // <private> in default circumstances
+            if trackName == nil, element.hasPrefix("mediaFormatinfo") {
+                guard let substring = element.firstSubstring(between: "\'", and: "\'") else { continue }
+                trackName = String(substring)
+                continue
+            }
+            
+            // notes: there is a field that may be "lossless", "high res lossless" and "stereo (lossy)"
+            
+            if isLossless == nil, element.hasPrefix(" sdFormatID") {
+                guard let substring = element.firstSubstring(between: "= ", and: .end) else { continue }
+                isLossless = substring == "alac"
+                continue
+            }
+            
+            if bitDepth == nil, element.hasPrefix(" sdBitDepth") {
+                guard let substring = element.firstSubstring(between: "= ", and: " bit") else { continue }
+                bitDepth = Int(substring)
+            }
+            
+            if sampleRate == nil, element.hasPrefix(" asbdSampleRate") {
+                guard let substring = element.firstSubstring(between: "= ", and: " kHz") else { continue }
+                let string = String(substring)
+                guard let double = Double(string) else { continue }
+                sampleRate = Int(double * 1000)
+                continue
+            }
+            
+        }
+        
+        // this requires an external profile to read this info
+        // might be helpful to prevent the early track sample rate switch issue.
+        // https://eclecticlight.co/2023/03/08/removing-privacy-censorship-from-the-log/
+        if let tn = trackName, tn == "<private>" {
+            trackName = nil
+        }
+        
+        guard let date, let isLossless, let sampleRate else { return }
+        
+        // discard if entry is known to be for lossy playback
+        // why?: while it could be nice to switch if you're playing a bunch of tracks where some are lossy,
+        //       occassionally, there are lossless tracks where logs start off with these lossy information.
+        //       to prevent over switching, i'm ignoring all lossy log entries.
+        guard isLossless else { return }
+        
+        let entry = CMEntry(date: date, trackName: trackName, bitDepth: bitDepth, sampleRate: sampleRate)
+//        print("\n\nXLINE", date, trackName, isLossless, bitDepth, sampleRate)
+//        print("\n\nLINE", date, split)
+        
+        entryStream.send(entry)
+    }
+}

--- a/Quality/MenuView.swift
+++ b/Quality/MenuView.swift
@@ -7,10 +7,13 @@
 
 import SwiftUI
 
+
 struct MenuView: View {
     
     @EnvironmentObject private var outputDevices: OutputDevices
     @EnvironmentObject private var defaults: Defaults
+    
+    @State var stream = LogReader()
     
     var body: some View {
         VStack {


### PR DESCRIPTION
- Borrows the `Process()` way of getting logs, rather than relying on `OSLogStore`, from #195, special thanks to @FantasticSkyBaby, which hopefully solves #115
- Hopefully fixes #190, #134?
- Best effort to match sample rate with track, aims to fix #159

IMPORTANT, for beta 1, a profile is needed, which can be downloaded and installed from https://eclecticlight.co/2023/03/08/removing-privacy-censorship-from-the-log/

Profile Direct Link: https://eclecticlight.co/wp-content/uploads/2023/03/enablelogprivatedata.zip 

You should always exercise caution by reading the above blog post to know what you're installing. Do also note that the profile is external, not made by me, and not signed by me either. 

This profile lets the app map sample rate data to whichever track its supposed to belong to, which helps with the #159 issue.

For beta 1, it will not work properly without the profile. This is because I'm slightly drained right now after a day spent on this, not logically clear how to infer which data belongs to which track, if that makes sense to you.

As per always, I make no guarantees that it will work. Hopefully it does though.

Warning: Code right now is a mess.