### PR TITLE
Fix: Prefer Sample Rate Multiples falls back within same family when intermediate rate is unsupported

### DIFF
--- a/Quality/OutputDevices.swift
+++ b/Quality/OutputDevices.swift
@@ -183,11 +183,26 @@ class OutputDevices: ObservableObject {
                 abs(Int32($0.mBitsPerChannel) - bitDepth) < abs(Int32($1.mBitsPerChannel) - bitDepth)
             })
             
+
             if Defaults.shared.userPreferSampleRateMultiples,
-               let nearestSampleRate = nearest,
-               nearestSampleRate != sampleRate, supported.contains(sampleRate / 2) {
-                nearest = sampleRate / 2
-            }
+                let nearestSampleRate = nearest,
+                nearestSampleRate != sampleRate {
+                    
+                    // Cast to Int for mathematically safe modulo operations
+                    let sourceInt = Int(sampleRate)
+                    let is44kFamily = sourceInt % 44100 == 0
+                    let baseRate = is44kFamily ? 44100 : 48000
+                    
+                    // Filter supported rates to match the family AND be strictly less than the source
+                    let familyRates = supported.filter {
+                        Int($0) % baseRate == 0 && $0 < sampleRate
+                    }
+                    
+                    // Fall back to the highest available matching rate
+                    if let bestMatch = familyRates.max() {
+                        nearest = bestMatch
+                    }
+                }
             
             let nearestFormat = formats.filter({
                 $0.mSampleRate == nearest && $0.mBitsPerChannel == nearestBitDepth?.mBitsPerChannel


### PR DESCRIPTION
Fixes #205

### Problem

When "Prefer Closest Sample Rate Multiple" is enabled and the device doesn't support the intermediate sample rate, the app falls back to the nearest overall rate, which may be cross-family.

Example: source at 176.4 kHz on a DAC supporting [44.1, 48, 96] kHz — the current code checks `supported.contains(sampleRate / 2)` once, finds 88.2 kHz unsupported, and falls back to 96 kHz (48 kHz family).

### Fix

Instead of a single halving check, identify the source rate's family (44.1 kHz or 48 kHz) and select the highest supported rate within that family below the source rate. Integer modulo is used instead of floating-point `truncatingRemainder` to avoid any IEEE 754 precision edge cases.

```swift
// Before (only checks one level down)
if supported.contains(sampleRate / 2) {
    nearest = sampleRate / 2
}

// After (walks the whole family)
let sourceInt = Int(sampleRate)
let is44kFamily = sourceInt % 44100 == 0
let baseRate = is44kFamily ? 44100 : 48000
let familyRates = supported.filter {
    Int($0) % baseRate == 0 && $0 < sampleRate
}
if let bestMatch = familyRates.max() {
    nearest = bestMatch
}
```

### Test cases verified on device

Tested on a Fosi Audio K5 Pro (USB, supports 44.1 / 48 / 96 kHz).

| Source | Device supports | Before | After |
|--------|----------------|--------|-------|
| 176.4 kHz | 44.1, 48, 96 | 96 kHz ✗ | 44.1 kHz ✓ |
| 96 kHz | 44.1, 48, 96 | 96 kHz ✓ | 96 kHz ✓ |
| 44.1 kHz | 44.1, 48, 96 | 44.1 kHz ✓ | 44.1 kHz ✓ |