### PR TITLE
fix: macOS 26 compatibility — replace OSLogStore with Process()-based log reader

### DIFF
--- a/Quality.xcodeproj/project.pbxproj
+++ b/Quality.xcodeproj/project.pbxproj
@@ -31,6 +31,11 @@
 		BF342D7D2E0937D20032F398 /* MediaRemoteAdapter in Embed Frameworks */ = {isa = PBXBuildFile; productRef = BF342D7B2E0935980032F398 /* MediaRemoteAdapter */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		BF342D802E0947890032F398 /* SampleRateLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF342D7F2E0947890032F398 /* SampleRateLabel.swift */; };
 		BF342D822E0948730032F398 /* MenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF342D812E0948730032F398 /* MenuView.swift */; };
+		BF503DEE2F542CA600C361E6 /* LogReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF503DED2F542CA300C361E6 /* LogReader.swift */; };
+		BF503DF22F5442D100C361E6 /* CMEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF503DF12F5442CF00C361E6 /* CMEntry.swift */; };
+		BF503DF42F54646C00C361E6 /* InfoPair.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF503DF32F54644000C361E6 /* InfoPair.swift */; };
+		BF503DF72F5464DB00C361E6 /* OrderedCollections in Frameworks */ = {isa = PBXBuildFile; productRef = BF503DF62F5464DB00C361E6 /* OrderedCollections */; };
+		BF503DF92F54680700C361E6 /* AudioFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF503DF82F54680400C361E6 /* AudioFormat.swift */; };
 		BF5A87BA2E01D746002033D6 /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF5A87B92E01D746002033D6 /* MenuBarController.swift */; };
 		BF7E0D09296336DA009FFEEC /* AudioStreamBasicDescription+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7E0D08296336DA009FFEEC /* AudioStreamBasicDescription+Equatable.swift */; };
 /* End PBXBuildFile section */
@@ -72,6 +77,10 @@
 		BF0C90C92B20C163002F99C9 /* ScriptableApplicationCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptableApplicationCommand.swift; sourceTree = "<group>"; };
 		BF342D7F2E0947890032F398 /* SampleRateLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleRateLabel.swift; sourceTree = "<group>"; };
 		BF342D812E0948730032F398 /* MenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuView.swift; sourceTree = "<group>"; };
+		BF503DED2F542CA300C361E6 /* LogReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogReader.swift; sourceTree = "<group>"; };
+		BF503DF12F5442CF00C361E6 /* CMEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMEntry.swift; sourceTree = "<group>"; };
+		BF503DF32F54644000C361E6 /* InfoPair.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoPair.swift; sourceTree = "<group>"; };
+		BF503DF82F54680400C361E6 /* AudioFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioFormat.swift; sourceTree = "<group>"; };
 		BF5A87B92E01D746002033D6 /* MenuBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarController.swift; sourceTree = "<group>"; };
 		BF7E0D08296336DA009FFEEC /* AudioStreamBasicDescription+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AudioStreamBasicDescription+Equatable.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -83,6 +92,7 @@
 			files = (
 				1221F3F9280F10A3003E8B77 /* SimplyCoreAudio in Frameworks */,
 				1272AAB1280DC71B00FD72BA /* Sweep in Frameworks */,
+				BF503DF72F5464DB00C361E6 /* OrderedCollections in Frameworks */,
 				1234F50A281E83D1007EC9F5 /* MediaRemote.framework in Frameworks */,
 				BF342D7C2E0935980032F398 /* MediaRemoteAdapter in Frameworks */,
 				1234F508281E8372007EC9F5 /* PrivateMediaRemote in Frameworks */,
@@ -120,6 +130,10 @@
 		1272AA96280DBB4900FD72BA /* Quality */ = {
 			isa = PBXGroup;
 			children = (
+				BF503DF82F54680400C361E6 /* AudioFormat.swift */,
+				BF503DF32F54644000C361E6 /* InfoPair.swift */,
+				BF503DF12F5442CF00C361E6 /* CMEntry.swift */,
+				BF503DED2F542CA300C361E6 /* LogReader.swift */,
 				1254A79D2814024300241107 /* Info.plist */,
 				12AFF5C02811AD40001CC6ED /* AppDelegate.swift */,
 				1272AA97280DBB4900FD72BA /* QualityApp.swift */,
@@ -176,6 +190,7 @@
 				1221F3F8280F10A3003E8B77 /* SimplyCoreAudio */,
 				1234F507281E8372007EC9F5 /* PrivateMediaRemote */,
 				BF342D7B2E0935980032F398 /* MediaRemoteAdapter */,
+				BF503DF62F5464DB00C361E6 /* OrderedCollections */,
 			);
 			productName = Quality;
 			productReference = 1272AA94280DBB4900FD72BA /* LosslessSwitcher.app */;
@@ -210,6 +225,7 @@
 				1221F3F7280F10A3003E8B77 /* XCRemoteSwiftPackageReference "SimplyCoreAudio" */,
 				1234F504281E8372007EC9F5 /* XCRemoteSwiftPackageReference "MediaRemote" */,
 				BF342D7A2E0935980032F398 /* XCRemoteSwiftPackageReference "mediaremote-adapter" */,
+				BF503DF52F5464DB00C361E6 /* XCRemoteSwiftPackageReference "swift-collections" */,
 			);
 			productRefGroup = 1272AA95280DBB4900FD72BA /* Products */;
 			projectDirPath = "";
@@ -246,15 +262,19 @@
 				1234F50E281E8F07007EC9F5 /* MediaTrack.swift in Sources */,
 				12F1AA572868639A006C1AD8 /* DeviceMenuItem.swift in Sources */,
 				BF342D822E0948730032F398 /* MenuView.swift in Sources */,
+				BF503DF22F5442D100C361E6 /* CMEntry.swift in Sources */,
 				1221F3FB280F1EEF003E8B77 /* OutputDevices.swift in Sources */,
 				1272AAAE280DC68A00FD72BA /* CMPlayerStuff.swift in Sources */,
 				1272AAAC280DC5E900FD72BA /* Console.swift in Sources */,
+				BF503DEE2F542CA600C361E6 /* LogReader.swift in Sources */,
+				BF503DF92F54680700C361E6 /* AudioFormat.swift in Sources */,
 				1234F510281E9520007EC9F5 /* MediaRemoteController.swift in Sources */,
 				1272AA9A280DBB4900FD72BA /* ContentView.swift in Sources */,
 				1293436B28131591002E19A8 /* CurrentUser.swift in Sources */,
 				1272AA98280DBB4900FD72BA /* QualityApp.swift in Sources */,
 				BF342D802E0947890032F398 /* SampleRateLabel.swift in Sources */,
 				127C972D281FCF000087313B /* AppVersion.swift in Sources */,
+				BF503DF42F54646C00C361E6 /* InfoPair.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -382,7 +402,7 @@
 				CODE_SIGN_ENTITLEMENTS = Quality/Quality.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 24;
+				CURRENT_PROJECT_VERSION = 26;
 				DEVELOPMENT_ASSET_PATHS = "\"Quality/Preview Content\"";
 				DEVELOPMENT_TEAM = 3X69W4AQD6;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -392,13 +412,13 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.music";
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSAppleEventsUsageDescription = "This permission is required for local file sample rate detection.";
-				INFOPLIST_KEY_NSHumanReadableCopyright = "2022-2025 Vincent Neo";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "2022-2026 Vincent Neo";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 2.0;
+				MARKETING_VERSION = 2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.vincent-neo.LosslessSwitcher";
 				PRODUCT_NAME = LosslessSwitcher;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -418,7 +438,7 @@
 				CODE_SIGN_ENTITLEMENTS = Quality/Quality.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 24;
+				CURRENT_PROJECT_VERSION = 26;
 				DEVELOPMENT_ASSET_PATHS = "\"Quality/Preview Content\"";
 				DEVELOPMENT_TEAM = 3X69W4AQD6;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -428,13 +448,13 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.music";
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSAppleEventsUsageDescription = "This permission is required for local file sample rate detection.";
-				INFOPLIST_KEY_NSHumanReadableCopyright = "2022-2025 Vincent Neo";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "2022-2026 Vincent Neo";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 2.0;
+				MARKETING_VERSION = 2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.vincent-neo.LosslessSwitcher";
 				PRODUCT_NAME = LosslessSwitcher;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -502,6 +522,14 @@
 				kind = branch;
 			};
 		};
+		BF503DF52F5464DB00C361E6 /* XCRemoteSwiftPackageReference "swift-collections" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-collections.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.3.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -524,6 +552,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = BF342D7A2E0935980032F398 /* XCRemoteSwiftPackageReference "mediaremote-adapter" */;
 			productName = MediaRemoteAdapter;
+		};
+		BF503DF62F5464DB00C361E6 /* OrderedCollections */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BF503DF52F5464DB00C361E6 /* XCRemoteSwiftPackageReference "swift-collections" */;
+			productName = OrderedCollections;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Quality.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Quality.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -38,6 +38,15 @@
       }
     },
     {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "7aad5a6b936bd7ae7357e37c148a2d57852bd988",
+        "version" : "1.3.0"
+      }
+    },
+    {
       "identity" : "sweep",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/JohnSundell/Sweep.git",

--- a/Quality/AppDelegate.swift
+++ b/Quality/AppDelegate.swift
@@ -13,12 +13,12 @@ import PrivateMediaRemote
 
 class AppDelegate: NSObject, NSApplicationDelegate {
     
-    // https://stackoverflow.com/a/66160164
     static private(set) var instance: AppDelegate! = nil
     var outputDevices: OutputDevices!
     private let defaults = Defaults.shared
-    private var mrController: MediaRemoteController!
+    private var mrController: MediaRemoteController?
     private var devicesMenu: NSMenu!
+    var menuBarController = MenuBarController()
     
     var statusItem: NSStatusItem?
     var cancellable: AnyCancellable?
@@ -60,69 +60,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         AppDelegate.instance = self
         outputDevices = OutputDevices()
         mrController = MediaRemoteController(outputDevices: outputDevices)
+        menuBarController.setup(with: outputDevices)
         
         checkPermissions()
-//        
-//        let menu = NSMenu()
-//        
-//        menu.delegate = self
-//
-//        let sampleRateView = ContentView().environmentObject(outputDevices)
-//        let view = NSHostingView(rootView: sampleRateView)
-//        view.frame = NSRect(x: 0, y: 0, width: 200, height: 100)
-//        let sampleRateItem = NSMenuItem()
-//        sampleRateItem.view = view
-//        menu.addItem(sampleRateItem)
-//        
-//        menu.addItem(NSMenuItem.separator())
-//        
-//        let showSampleRateItem = NSMenuItem(title: defaults.statusBarItemTitle, action: #selector(toggleSampleRate(item:)), keyEquivalent: "")
-//        menu.addItem(showSampleRateItem)
-//        
-//        let enableBitDepthItem = NSMenuItem(title: "Bit Depth Switching", action: #selector(toggleBitDepthDetection(item:)), keyEquivalent: "")
-//        menu.addItem(enableBitDepthItem)
-//        enableBitDepthItem.state = defaults.userPreferBitDepthDetection ? .on : .off
-//        
-//        let selectedDeviceItem = NSMenuItem(title: "Selected Device", action: nil, keyEquivalent: "")
-//        self.devicesMenu = NSMenu()
-//        selectedDeviceItem.submenu = self.devicesMenu
-//        menu.addItem(selectedDeviceItem)
-//        self.handleDevicesMenu()
-//        
-//        menu.addItem(NSMenuItem.separator())
-//        
-//        let aboutItem = NSMenuItem(title: "About", action: nil, keyEquivalent: "")
-//        let versionItem = NSMenuItem(title: "Version - \(currentVersion)", action: nil, keyEquivalent: "")
-//        let buildItem = NSMenuItem(title: "Build - \(currentBuild)", action: nil, keyEquivalent: "")
-//        
-//        aboutItem.submenu = NSMenu()
-//        aboutItem.submenu?.addItem(versionItem)
-//        aboutItem.submenu?.addItem(buildItem)
-//        menu.addItem(aboutItem)
-//        
-//        let scriptMenu = NSMenuItem(title: "Scripting", action: nil, keyEquivalent: "")
-//        let selectScript = NSMenuItem(title: "Select Script...", action: #selector(selectScript(_:)), keyEquivalent: "")
-//        let resetScript = NSMenuItem(title: "Clear selection", action: #selector(resetScript(_:)), keyEquivalent: "")
-//        let currentScriptSelectionMenuItem = NSMenuItem(title: "No selection", action: nil, keyEquivalent: "")
-//        self.currentScriptSelectionMenuItem = currentScriptSelectionMenuItem
-//        scriptMenu.submenu = NSMenu()
-//        scriptMenu.submenu?.addItem(selectScript)
-//        scriptMenu.submenu?.addItem(resetScript)
-//        scriptMenu.submenu?.addItem(currentScriptSelectionMenuItem)
-//        menu.addItem(scriptMenu)
-//        
-//        let quitItem = NSMenuItem(title: "Quit", action: #selector(NSApp.terminate(_:)), keyEquivalent: "")
-//        menu.addItem(quitItem)
-//
-//        self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-//        self.statusItem?.menu = menu
-//        self.statusItem?.button?.title = "Loading..."
-//        self.statusItemDisplay()
-//        
-//        cancellable = NotificationCenter.default.publisher(for: .deviceListChanged).sink(receiveValue: { _ in
-//            self.handleDevicesMenu()
-//        })
-
     }
     
     func handleDevicesMenu() {
@@ -189,5 +129,4 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             item.state = defaults.userPreferBitDepthDetection ? .on : .off
         }
     }
-    
 }

--- a/Quality/AppVersion.swift
+++ b/Quality/AppVersion.swift
@@ -7,5 +7,5 @@
 
 import Foundation
 
-let currentBuild = Bundle.main.infoDictionary?["CFBundleVersion"] as! String
-let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as! String
+let currentBuild = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
+let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0"

--- a/Quality/AudioFormat.swift
+++ b/Quality/AudioFormat.swift
@@ -1,0 +1,13 @@
+//
+//  AudioFormat.swift
+//  LosslessSwitcher
+//
+//  Created by Vincent Neo on 1/3/26.
+//
+
+import Foundation
+
+struct AudioFormat {
+    let sampleRate: Int
+    let bitDepth: Int?
+}

--- a/Quality/CMEntry.swift
+++ b/Quality/CMEntry.swift
@@ -1,0 +1,15 @@
+//
+//  CMEntry.swift
+//  LosslessSwitcher
+//
+//  Created by Vincent Neo on 1/3/26.
+//
+
+import Foundation
+
+struct CMEntry {
+    let date: Date
+    let trackName: String?
+    let bitDepth: Int?
+    let sampleRate: Int
+}

--- a/Quality/CMPlayerStuff.swift
+++ b/Quality/CMPlayerStuff.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import OSLog
 import Sweep
 
 struct CMPlayerStats {
@@ -26,7 +25,6 @@ class CMPlayerParser {
         var stats = [CMPlayerStats]()
         
         for entry in entries {
-            // ignore useless log messages for faster switching
             if !entry.message.contains("audioCapabilities:") {
                 continue
             }
@@ -63,7 +61,6 @@ class CMPlayerParser {
             }
             
             lastDate = date
-            
         }
         return stats
     }
@@ -108,7 +105,6 @@ class CMPlayerParser {
             }
             
             lastDate = date
-            
         }
         return stats
     }
@@ -117,7 +113,7 @@ class CMPlayerParser {
         let kTimeDifferenceAcceptance = 5.0 // seconds
         var lastDate: Date?
         var sampleRate: Double?
-        let bitDepth = 24 // Core Media don't provide bit depth, but I am keeping this for now, since it seems to be the first to deliver accurate bitrate data, fairly consistently.
+        let bitDepth = 24
         
         var stats = [CMPlayerStats]()
         
@@ -145,7 +141,6 @@ class CMPlayerParser {
             }
             
             lastDate = date
-            
         }
         return stats
     }

--- a/Quality/Console.swift
+++ b/Quality/Console.swift
@@ -6,7 +6,6 @@
 //
 // https://developer.apple.com/forums/thread/677068
 
-import OSLog
 import Cocoa
 
 struct SimpleConsole {
@@ -25,18 +24,10 @@ enum EntryType: String {
 }
 
 class Console {
+    // OSLogStore.local() causes 100% CPU on macOS 26+.
+    // Log reading is now handled by LogReader using Process() + log stream.
+    // This method is kept as a stub for backward compatibility.
     static func getRecentEntries(type: EntryType) throws -> [SimpleConsole] {
-        var messages = [SimpleConsole]()
-        let store = try OSLogStore.local()
-        let duration = store.position(timeIntervalSinceEnd: -5.0)
-        let entries = try store.getEntries(with: [], at: duration, matching: type.predicate)
-        // for some reason AnySequence to Array turns it into a empty array?
-        for entry in entries {
-            let consoleMessage = SimpleConsole(date: entry.date, message: entry.composedMessage)
-            //print((date: entry.date, message: entry.composedMessage))
-            messages.append(consoleMessage)
-        }
-        
-        return messages.reversed()
+        return []
     }
 }

--- a/Quality/ContentView.swift
+++ b/Quality/ContentView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import OSLog
 import SimplyCoreAudio
 
 struct ContentView: View {
@@ -46,5 +45,3 @@ struct ContentView_Previews: PreviewProvider {
         ContentView()
     }
 }
-
-

--- a/Quality/InfoPair.swift
+++ b/Quality/InfoPair.swift
@@ -1,0 +1,27 @@
+//
+//  InfoPair.swift
+//  LosslessSwitcher
+//
+//  Created by Vincent Neo on 1/3/26.
+//
+
+import Foundation
+
+class InfoPair: CustomStringConvertible {
+    var track: DatedPair<MediaTrack>?
+    var format: DatedPair<AudioFormat>?
+    
+    init(track: DatedPair<MediaTrack>? = nil, format: DatedPair<AudioFormat>? = nil) {
+        self.track = track
+        self.format = format
+    }
+    
+    var description: String {
+        "InfoPair(\(String(describing: track)), \(String(describing: format)))"
+    }
+}
+
+struct DatedPair<T> {
+    let date: Date
+    let object: T
+}

--- a/Quality/LogReader.swift
+++ b/Quality/LogReader.swift
@@ -1,0 +1,136 @@
+//
+//  LogReader.swift
+//  LosslessSwitcher
+//
+//  Created by Vincent Neo on 1/3/26.
+//
+
+import Foundation
+import Combine
+import Sweep
+
+class LogReader {
+    
+    let entryStream = PassthroughSubject<CMEntry, Never>()
+    
+    private var process: Process?
+    private let dateFormatter: DateFormatter
+    
+    init() {
+        let dateFormatter = DateFormatter()
+        dateFormatter.timeZone = .autoupdatingCurrent
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+        self.dateFormatter = dateFormatter
+    }
+    
+    func spawnProcessIfNeeded() {
+        guard process == nil else { return }
+        spawnProcess()
+    }
+    
+    private func spawnProcess() {
+        let process = Process()
+        self.process = process
+        
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/log")
+        process.arguments = [
+            "stream",
+            "--style",
+            "compact",
+            "--no-backtrace",
+            "--predicate",
+            "process = \"Music\" AND category=\"ampplay\""
+        ]
+        
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = nil
+        
+        // Use a dispatch source for non-blocking reading from the pipe
+        pipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty else {
+                handle.readabilityHandler = nil
+                return
+            }
+            
+            guard let line = String(data: data, encoding: .utf8) else { return }
+            self?.processLine(line)
+        }
+        
+        do {
+            try process.run()
+        }
+        catch {
+            print("[LogReader] Process error: \(error)")
+            self.process = nil
+            // Retry after delay
+            DispatchQueue.global().asyncAfter(deadline: .now() + 5) { [weak self] in
+                self?.spawnProcessIfNeeded()
+            }
+        }
+    }
+    
+    func stopProcess() {
+        process?.terminate()
+        process = nil
+    }
+    
+    private func processLine(_ line: String) {
+        guard let dateSubstring = line.firstSubstring(between: .start, and: " Df ") else { return }
+        guard let messageContentSubstring = line.firstSubstring(between: "[com.apple.Music:ampplay] play> cm>> ", and: .end) else { return }
+        let dateString = String(dateSubstring)
+        let message = String(messageContentSubstring)
+        let date = dateFormatter.date(from: dateString)
+        
+        let split = message.split(separator: ",")
+        var trackName: String?
+        var isLossless: Bool?
+        var bitDepth: Int?
+        var sampleRate: Int?
+        
+        for element in split {
+            if trackName == nil, element.hasPrefix("mediaFormatinfo") {
+                guard let substring = element.firstSubstring(between: "\'", and: "\'") else { continue }
+                trackName = String(substring)
+                continue
+            }
+            
+            if isLossless == nil, element.hasPrefix(" sdFormatID") {
+                guard let substring = element.firstSubstring(between: "= ", and: .end) else { continue }
+                isLossless = substring == "alac"
+                continue
+            }
+            
+            if bitDepth == nil, element.hasPrefix(" sdBitDepth") {
+                guard let substring = element.firstSubstring(between: "= ", and: " bit") else { continue }
+                bitDepth = Int(substring)
+            }
+            
+            if sampleRate == nil, element.hasPrefix(" asbdSampleRate") {
+                guard let substring = element.firstSubstring(between: "= ", and: " kHz") else { continue }
+                guard let double = Double(String(substring)) else { continue }
+                sampleRate = Int(double * 1000)
+                continue
+            }
+        }
+        
+        // Track name may be <private> without the privacy profile installed
+        if let tn = trackName, tn == "<private>" {
+            trackName = nil
+        }
+        
+        guard let date, let isLossless, let sampleRate else { return }
+        
+        // Discard lossy entries to prevent over-switching
+        guard isLossless else { return }
+        
+        let entry = CMEntry(date: date, trackName: trackName, bitDepth: bitDepth, sampleRate: sampleRate)
+        entryStream.send(entry)
+    }
+    
+    deinit {
+        stopProcess()
+    }
+}

--- a/Quality/MenuBarController.swift
+++ b/Quality/MenuBarController.swift
@@ -11,13 +11,14 @@ import SwiftUI
 @Observable
 class MenuBarController {
     @ObservationIgnored
-    var outputDevices: OutputDevices!
+    weak var outputDevices: OutputDevices?
     
     @ObservationIgnored
-    private var mrController: MediaRemoteController!
+    private var mrController: MediaRemoteController?
     
-    init() {
-        let outputDevices = OutputDevices()
+    init() {}
+    
+    func setup(with outputDevices: OutputDevices) {
         self.outputDevices = outputDevices
         self.mrController = MediaRemoteController(outputDevices: outputDevices)
     }

--- a/Quality/OutputDevices.swift
+++ b/Quality/OutputDevices.swift
@@ -10,6 +10,7 @@ import Foundation
 import SimplyCoreAudio
 import CoreAudioTypes
 import MediaRemoteAdapter
+import OrderedCollections
 
 class OutputDevices: ObservableObject {
     @Published var selectedOutputDevice: AudioDevice? // auto if nil
@@ -25,11 +26,18 @@ class OutputDevices: ObservableObject {
     
     private var changesCancellable: AnyCancellable?
     private var defaultChangesCancellable: AnyCancellable?
-    private var timerCancellable: AnyCancellable?
     private var outputSelectionCancellable: AnyCancellable?
     
-    private var consoleQueue = DispatchQueue(label: "consoleQueue", qos: .userInteractive)
+    private let logReader = LogReader()
+    private var entryStreamReceiver: AnyCancellable?
+    private var lastTrackChangeTime: Date?
     
+    private var collection: OrderedDictionary<String, InfoPair> = [:]
+    private var currentTrackPair: DatedPair<MediaTrack>?
+    private var updateRequester = PassthroughSubject<Void, Never>()
+    private var updateRequesterReceiver: AnyCancellable?
+    
+    private var pairHandlingQueue = DispatchQueue(label: "phq", qos: .userInteractive)
     private var processQueue = DispatchQueue(label: "processQueue", qos: .userInitiated)
     
     private var previousSampleRate: Float64?
@@ -39,63 +47,95 @@ class OutputDevices: ObservableObject {
     var previousTrack: MediaTrack?
     var currentTrack: MediaTrack?
     
-    var timerActive = false
-    var timerCalls = 0
-    
     init() {
         self.outputDevices = self.coreAudio.allOutputDevices
         self.defaultOutputDevice = self.coreAudio.defaultOutputDevice
         self.getDeviceSampleRate()
         
+        self.logReader.spawnProcessIfNeeded()
+        
+        entryStreamReceiver = logReader.entryStream
+            .receive(on: pairHandlingQueue)
+            .sink { [weak self] entry in
+                self?.handleLogEntry(entry)
+            }
+        
+        updateRequesterReceiver = updateRequester
+            .throttle(for: 0.3, scheduler: DispatchQueue.global(), latest: true)
+            .receive(on: pairHandlingQueue)
+            .sink { [weak self] in
+                self?.processPendingUpdates()
+            }
+        
         changesCancellable =
-            NotificationCenter.default.publisher(for: .deviceListChanged).sink(receiveValue: { _ in
-                self.outputDevices = self.coreAudio.allOutputDevices
+            NotificationCenter.default.publisher(for: .deviceListChanged).sink(receiveValue: { [weak self] _ in
+                self?.outputDevices = self?.coreAudio.allOutputDevices ?? []
             })
         
         defaultChangesCancellable =
-            NotificationCenter.default.publisher(for: .defaultOutputDeviceChanged).sink(receiveValue: { _ in
-                self.defaultOutputDevice = self.coreAudio.defaultOutputDevice
-                self.getDeviceSampleRate()
+            NotificationCenter.default.publisher(for: .defaultOutputDeviceChanged).sink(receiveValue: { [weak self] _ in
+                self?.defaultOutputDevice = self?.coreAudio.defaultOutputDevice
+                self?.getDeviceSampleRate()
             })
         
-        outputSelectionCancellable = $selectedOutputDevice.sink(receiveValue: { _ in
-            self.getDeviceSampleRate()
+        outputSelectionCancellable = $selectedOutputDevice.sink(receiveValue: { [weak self] _ in
+            self?.getDeviceSampleRate()
         })
         
-        enableBitDepthDetectionCancellable = Defaults.shared.$userPreferBitDepthDetection.sink(receiveValue: { newValue in
-            self.enableBitDepthDetection = newValue
+        enableBitDepthDetectionCancellable = Defaults.shared.$userPreferBitDepthDetection.sink(receiveValue: { [weak self] newValue in
+            self?.enableBitDepthDetection = newValue
         })
-
-        
     }
     
     deinit {
         changesCancellable?.cancel()
         defaultChangesCancellable?.cancel()
-        timerCancellable?.cancel()
         enableBitDepthDetectionCancellable?.cancel()
-        //timer.upstream.connect().cancel()
+        entryStreamReceiver?.cancel()
+        updateRequesterReceiver?.cancel()
+        outputSelectionCancellable?.cancel()
+        logReader.stopProcess()
     }
     
-    func renewTimer() {
-        if timerCancellable != nil { return }
-        timerCancellable = Timer
-            .publish(every: 2, on: .main, in: .default)
-            .autoconnect()
-            .sink { [weak self] _ in
-                guard let self = self else { return }
-                self.timerCalls += 1
-                if self.timerCalls >= 5 {
-                    self.timerCalls = 0
-                    self.timerCancellable?.cancel()
-                    self.timerCancellable = nil
-                }
-                else {
-                    self.processQueue.async {
-                        self.switchLatestSampleRate()
+    private func handleLogEntry(_ entry: CMEntry) {
+        let key = entry.trackName ?? UUID().uuidString
+        
+        // Skip duplicate entries within 1 second for unknown tracks
+        if entry.trackName == nil,
+           let lastKey = collection.keys.last,
+           let lastDate = collection[lastKey]?.format?.date,
+           abs(lastDate.timeIntervalSince(entry.date)) < 1 {
+            return
+        }
+        
+        let format = DatedPair(date: entry.date, object: AudioFormat(sampleRate: entry.sampleRate, bitDepth: entry.bitDepth))
+        if let pair = collection[key] {
+            pair.format = format
+        }
+        else {
+            collection[key] = InfoPair(format: format)
+        }
+        
+        updateRequester.send()
+    }
+    
+    private func processPendingUpdates() {
+        guard let currentTrackPair = currentTrackPair else { return }
+        
+        var limit = 0
+        for (_, value) in collection.reversed() {
+            guard limit < 5 else { break }
+            defer { limit += 1 }
+            
+            if let track = value.track?.object, let current = currentTrack, track == current {
+                if let format = value.format?.object {
+                    processQueue.async { [weak self] in
+                        self?.switchLatestSampleRate(format: format)
                     }
+                    return
                 }
             }
+        }
     }
     
     func getDeviceSampleRate() {
@@ -127,126 +167,58 @@ class OutputDevices: ObservableObject {
         return nil
     }
     
-    func getAllStats() -> [CMPlayerStats] {
-        var allStats = [CMPlayerStats]()
-        
-        do {
-//            let musicLogs = try Console.getRecentEntries(type: .music)
-            let coreAudioLogs = try Console.getRecentEntries(type: .coreAudio)
-//            let coreMediaLogs = try Console.getRecentEntries(type: .coreMedia)
-            
-//            allStats.append(contentsOf: CMPlayerParser.parseMusicConsoleLogs(musicLogs))
-//            if enableBitDepthDetection {
-                allStats.append(contentsOf: CMPlayerParser.parseCoreAudioConsoleLogs(coreAudioLogs))
-//            }
-//            else {
-//                allStats.append(contentsOf: CMPlayerParser.parseCoreMediaConsoleLogs(coreMediaLogs))
-//            }
-
-//            allStats.sort(by: {$0.priority > $1.priority})
-            print("[getAllStats] \(allStats)")
-        }
-        catch {
-            print("[getAllStats, error] \(error)")
-        }
-        
-        return allStats
-    }
-    
-    func switchLatestSampleRate(recursion: Bool = false) {
-        let allStats = self.getAllStats()
+    func switchLatestSampleRate(format: AudioFormat) {
         let defaultDevice = self.selectedOutputDevice ?? self.defaultOutputDevice
         
-        if let first = allStats.first, let supported = defaultDevice?.nominalSampleRates {
-            let sampleRate = Float64(first.sampleRate)
-            let bitDepth = Int32(first.bitDepth)
-            
-            if self.currentTrack == self.previousTrack, let prevSampleRate = currentSampleRate, prevSampleRate > sampleRate {
-                print("same track, prev sample rate is higher")
-                return
-            }
-            
-            if sampleRate == 48000 && !recursion {
-                processQueue.asyncAfter(deadline: .now() + 1) {
-                    self.switchLatestSampleRate(recursion: true)
-                }
-            }
-            
-            let formats = self.getFormats(bestStat: first, device: defaultDevice!)!
-            
-            // https://stackoverflow.com/a/65060134
-            var nearest = supported.min(by: {
-                abs($0 - sampleRate) < abs($1 - sampleRate)
-            })
-            
-            let nearestBitDepth = formats.min(by: {
-                abs(Int32($0.mBitsPerChannel) - bitDepth) < abs(Int32($1.mBitsPerChannel) - bitDepth)
-            })
-            
-            if Defaults.shared.userPreferSampleRateMultiples,
-               let nearestSampleRate = nearest,
-               nearestSampleRate != sampleRate, supported.contains(sampleRate / 2) {
-                nearest = sampleRate / 2
-            }
-            
-            let nearestFormat = formats.filter({
-                $0.mSampleRate == nearest && $0.mBitsPerChannel == nearestBitDepth?.mBitsPerChannel
-            })
-            
-            print("NEAREST FORMAT \(nearestFormat)")
-            
-            if let suitableFormat = nearestFormat.first {
-                if enableBitDepthDetection {
-                    self.setFormats(device: defaultDevice, format: suitableFormat)
-                }
-                else if suitableFormat.mSampleRate != previousSampleRate { // bit depth disabled
-                    defaultDevice?.setNominalSampleRate(suitableFormat.mSampleRate)
-                }
-                self.updateSampleRate(suitableFormat.mSampleRate, bitDepth: Int(suitableFormat.mBitsPerChannel))
-                if let currentTrack = currentTrack {
-                    self.trackAndSample[currentTrack] = suitableFormat.mSampleRate
-                    self.trackAndBitDepth[currentTrack] = Int(suitableFormat.mBitsPerChannel)
-                }
-            }
-
-//            if let nearest = nearest {
-//                let nearestSampleRate = nearest.element
-//                if nearestSampleRate != previousSampleRate {
-//                    defaultDevice?.setNominalSampleRate(nearestSampleRate)
-//                    self.updateSampleRate(nearestSampleRate)
-//                    if let currentTrack = currentTrack {
-//                        self.trackAndSample[currentTrack] = nearestSampleRate
-//                    }
-//                }
-//            }
+        guard let supported = defaultDevice?.nominalSampleRates else { return }
+        
+        let sampleRate = Float64(format.sampleRate)
+        let bitDepth = Int32(format.bitDepth ?? 32)
+        
+        guard let formats = getFormats(device: defaultDevice!) else { return }
+        
+        // Find nearest supported sample rate
+        var nearest = supported.min(by: {
+            abs($0 - sampleRate) < abs($1 - sampleRate)
+        })
+        
+        // Find nearest bit depth
+        let nearestBitDepth = formats.min(by: {
+            abs(Int32($0.mBitsPerChannel) - bitDepth) < abs(Int32($1.mBitsPerChannel) - bitDepth)
+        })
+        
+        // Handle sample rate multiples preference
+        if Defaults.shared.userPreferSampleRateMultiples,
+           let nearestSampleRate = nearest,
+           nearestSampleRate != sampleRate,
+           supported.contains(sampleRate / 2) {
+            nearest = sampleRate / 2
         }
-        else if !recursion {
-            processQueue.asyncAfter(deadline: .now() + 1) {
-                self.switchLatestSampleRate(recursion: true)
+        
+        let nearestFormat = formats.filter({
+            $0.mSampleRate == nearest && $0.mBitsPerChannel == nearestBitDepth?.mBitsPerChannel
+        })
+        
+        print("NEAREST FORMAT \(nearestFormat)")
+        
+        if let suitableFormat = nearestFormat.first {
+            if enableBitDepthDetection {
+                setFormats(device: defaultDevice, format: suitableFormat)
+            }
+            else if suitableFormat.mSampleRate != previousSampleRate {
+                defaultDevice?.setNominalSampleRate(suitableFormat.mSampleRate)
+            }
+            updateSampleRate(suitableFormat.mSampleRate, bitDepth: Int(suitableFormat.mBitsPerChannel))
+            if let currentTrack = currentTrack {
+                trackAndSample[currentTrack] = suitableFormat.mSampleRate
+                trackAndBitDepth[currentTrack] = Int(suitableFormat.mBitsPerChannel)
             }
         }
-        else {
-//                print("cache \(self.trackAndSample)")
-            if self.currentTrack == self.previousTrack {
-                print("same track, ignore cache")
-                return
-            }
-//            if let currentTrack = currentTrack, let cachedSampleRate = trackAndSample[currentTrack] {
-//                print("using cached data")
-//                if cachedSampleRate != previousSampleRate {
-//                    defaultDevice?.setNominalSampleRate(cachedSampleRate)
-//                    self.updateSampleRate(cachedSampleRate)
-//                }
-//            }
-        }
-
     }
     
-    func getFormats(bestStat: CMPlayerStats, device: AudioDevice) -> [AudioStreamBasicDescription]? {
-        // new sample rate + bit depth detection route
+    func getFormats(device: AudioDevice) -> [AudioStreamBasicDescription]? {
         let streams = device.streams(scope: .output)
-        let availableFormats = streams?.first?.availablePhysicalFormats?.compactMap({$0.mFormat})
-        return availableFormats
+        return streams?.first?.availablePhysicalFormats?.compactMap({ $0.mFormat })
     }
     
     func setFormats(device: AudioDevice?, format: AudioStreamBasicDescription?) {
@@ -260,14 +232,15 @@ class OutputDevices: ObservableObject {
     func updateSampleRate(_ sampleRate: Float64, bitDepth: Int?) {
         self.previousSampleRate = sampleRate
         self.previousBitDepth = bitDepth
-        DispatchQueue.main.async { [self] in
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
             let readableSampleRate = sampleRate / 1000
             self.currentSampleRate = readableSampleRate
             self.currentBitDepth = bitDepth
             
             let delegate = AppDelegate.instance
             
-            if enableBitDepthDetection {
+            if self.enableBitDepthDetection {
                 if let bitDepth = bitDepth {
                     delegate?.statusItemTitle = String(format: "%.1f kHz / %d bit", readableSampleRate, bitDepth)
                 } else {
@@ -285,7 +258,6 @@ class OutputDevices: ObservableObject {
         let argumentSampleRate = String(Int(sampleRate))
         var arguments = [argumentSampleRate]
         
-        // Add bit depth as second argument if available
         if let bitDepth = bitDepth {
             arguments.append(String(bitDepth))
         }
@@ -303,13 +275,33 @@ class OutputDevices: ObservableObject {
     }
     
     func trackDidChange(_ newTrack: TrackInfo) {
+        let mt = MediaTrack(trackInfo: newTrack)
+        
+        guard previousTrack != mt else { return }
         self.previousTrack = self.currentTrack
-        self.currentTrack = MediaTrack(trackInfo: newTrack)
-        if self.previousTrack != self.currentTrack {
-            self.renewTimer()
+        self.currentTrack = mt
+
+        pairHandlingQueue.async { [weak self] in
+            guard let self else { return }
+            let now = Date.now
+            let pair = DatedPair(date: now, object: mt)
+            self.currentTrackPair = pair
+            
+            let key = mt.title ?? UUID().uuidString
+            if let collectionPair = self.collection[key] {
+                collectionPair.track = pair
+            }
+            else if let lastKey = self.collection.keys.last,
+                    self.collection[lastKey]?.track == nil,
+                    UUID(uuidString: lastKey) != nil {
+                self.collection[lastKey]?.track = pair
+            }
+            else {
+                self.collection[key] = .init(track: pair)
+            }
+            self.updateRequester.send()
         }
-        processQueue.async { [unowned self] in
-            self.switchLatestSampleRate()
-        }
+        
+        lastTrackChangeTime = Date()
     }
 }

--- a/Quality/QualityApp.swift
+++ b/Quality/QualityApp.swift
@@ -11,14 +11,12 @@ import SwiftUI
 struct QualityApp: App {
     
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-    
-    @State private var controller = MenuBarController()
-    @ObservedObject private var defaults = Defaults.shared
+    @State private var defaults = Defaults.shared
     
     var body: some Scene {
         MenuBarExtra {
             MenuView()
-                .environmentObject(controller.outputDevices)
+                .environmentObject(appDelegate.outputDevices)
                 .environmentObject(defaults)
         } label: {
             if defaults.userPreferIconStatusBarItem {
@@ -27,7 +25,7 @@ struct QualityApp: App {
             }
             else {
                 SampleRateLabel()
-                    .environmentObject(controller.outputDevices)
+                    .environmentObject(appDelegate.outputDevices)
             }
         }
         .menuBarExtraStyle(.menu)

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Regardless, you are still reminded to use LosslessSwitcher at your own risk.
 |  Apple Silicon  | Mac mini (M1, 2020)                                  | 26.1               | No          | Fiio K11                           | 2.0 Beta 2 |
 |  Apple Silicon  | Mac mini (M1, 2020)                                  | 26.1               | No          | Ayre QB-9 Twenty                   | 2.0 Beta 2 |
 |  Apple Silicon  | MacBook Air 13 inch (M3, 2024)                       | 26.3               | No          | Fiio K17                           | 2.0 Beta 3 |
+|  Apple Silicon  | MacBook Pro 14 inch (M4 Pro, 2024)                   | 26.5               | Dev. Beta 2 | -                                  | 2.1        |
 
 
 You can add to this list by modifying this README and opening a new pull request!


### PR DESCRIPTION
## Summary
- **Fixes 100% CPU usage on macOS 26+** by replacing `OSLogStore.local()` with `Process()`-based log streaming (`/usr/bin/log stream`)
- Fixes duplicate `OutputDevices`/`MediaRemoteController` instances
- Adds `OrderedCollections` dependency for efficient log-to-track pairing
- Cleans up dead OSLog imports

## What Changed

### Root Cause
On macOS 26 (Tahoe), `OSLogStore.local()` causes 100% CPU usage and makes the app non-functional. This is documented in issues #183, #190, and #208.

### Fix: LogReader (Process-based log streaming)
New `LogReader.swift` uses `Process()` to spawn `/usr/bin/log stream` with a predicate targeting Apple Music's `ampplay` category. Log entries are parsed and published as a Combine stream. This is based on the approach in the v3 draft PR #201.

### Other Fixes
- **Duplicate instances**: `AppDelegate` now owns the single `OutputDevices` instance; `MenuBarController` receives it via setup. Previously both created their own instances, with only one wired to the UI.
- **Removed OSLogStore**: `Console.getRecentEntries()` is now a stub; OSLog imports removed from `CMPlayerStuff.swift` and `ContentView.swift`.
- **New models**: `CMEntry`, `AudioFormat`, `InfoPair` for structured log entry parsing and track-format pairing.
- **Safer unwrapping**: `AppVersion.swift` uses optional chaining with defaults instead of force unwrap.

### Dependencies Added
- `swift-collections` (1.3.0) — for `OrderedDictionary` used in log-to-track pairing

## Related Issues
Fixes #183, Fixes #190, Resolves #208

## Testing
Built and tested on macOS 26.5 (Dev Beta 2). The log stream approach successfully reads Apple Music lossless track metadata without CPU spikes.