### PR TITLE
Warn when Dolby Atmos is hijacking the lossless stream

### DIFF
--- a/Quality/CMPlayerStuff.swift
+++ b/Quality/CMPlayerStuff.swift
@@ -124,24 +124,25 @@ class CMPlayerParser {
     /// window contains no decode info — callers should keep the previous value in
     /// that case rather than flip-flopping during steady playback.
     static func detectAtmos(_ entries: [SimpleConsole]) -> Bool? {
-        var sawLossless = false
-        var sawLossyAAC = false
-
+        // `entries` are newest-first (Console.getRecentEntries reverses the
+        // chronological order), so the first decoder line we encounter is the
+        // most recent. Decide on that and stop, rather than letting any
+        // occurrence in the window decide — otherwise a stale decoder line from
+        // the previous track (e.g. an `alac` line still in the window right
+        // after switching into Atmos) could outvote the current one.
         for entry in entries {
             let message = entry.message
             if message.contains("ACAppleLosslessDecoder.cpp") {
-                sawLossless = true
+                return false // most recent decode is lossless -> not Atmos
             }
             if message.contains("ACMP4AACBaseDecoder.cpp"),
                message.contains("Output format:"),
                message.contains("48000 Hz") {
-                sawLossyAAC = true
+                return true  // most recent decode is the lossy AAC (Atmos/Spatial) asset
             }
         }
 
-        if sawLossless { return false }  // a lossless stream is decoding -> not Atmos
-        if sawLossyAAC  { return true }   // lossy AAC @ 48 kHz, no lossless -> Atmos/Spatial
-        return nil                        // no decode info in window -> unknown
+        return nil // no decode info in this window -> keep previous value
     }
 
     static func parseCoreMediaConsoleLogs(_ entries: [SimpleConsole]) -> [CMPlayerStats] {

--- a/Quality/CMPlayerStuff.swift
+++ b/Quality/CMPlayerStuff.swift
@@ -113,6 +113,37 @@ class CMPlayerParser {
         return stats
     }
     
+    /// Detects whether Music is playing a lossy Dolby Atmos / Spatial stream
+    /// instead of a Lossless one, using the same CoreAudio logs we already fetch.
+    ///
+    /// - Lossless playback decodes via `ACAppleLosslessDecoder` (subType `alac`).
+    /// - Atmos / Spatial playback bypasses lossless entirely and decodes the lossy
+    ///   AAC asset (`ACMP4AACBaseDecoder`, `Output format: ... 48000 Hz`).
+    ///
+    /// Returns `true` (Atmos), `false` (Lossless), or `nil` when the recent log
+    /// window contains no decode info — callers should keep the previous value in
+    /// that case rather than flip-flopping during steady playback.
+    static func detectAtmos(_ entries: [SimpleConsole]) -> Bool? {
+        var sawLossless = false
+        var sawLossyAAC = false
+
+        for entry in entries {
+            let message = entry.message
+            if message.contains("ACAppleLosslessDecoder.cpp") {
+                sawLossless = true
+            }
+            if message.contains("ACMP4AACBaseDecoder.cpp"),
+               message.contains("Output format:"),
+               message.contains("48000 Hz") {
+                sawLossyAAC = true
+            }
+        }
+
+        if sawLossless { return false }  // a lossless stream is decoding -> not Atmos
+        if sawLossyAAC  { return true }   // lossy AAC @ 48 kHz, no lossless -> Atmos/Spatial
+        return nil                        // no decode info in window -> unknown
+    }
+
     static func parseCoreMediaConsoleLogs(_ entries: [SimpleConsole]) -> [CMPlayerStats] {
         let kTimeDifferenceAcceptance = 5.0 // seconds
         var lastDate: Date?

--- a/Quality/MenuView.swift
+++ b/Quality/MenuView.swift
@@ -14,8 +14,14 @@ struct MenuView: View {
     
     var body: some View {
         VStack {
+            if outputDevices.isAtmosActive {
+                Text("⚠️ Dolby Atmos is on — not playing in Lossless")
+                    .foregroundColor(.red)
+                Divider()
+            }
+
             ContentView()
-            
+
             Divider()
             
             Button {

--- a/Quality/OutputDevices.swift
+++ b/Quality/OutputDevices.swift
@@ -17,6 +17,7 @@ class OutputDevices: ObservableObject {
     @Published var outputDevices = [AudioDevice]()
     @Published var currentSampleRate: Float64?
     @Published var currentBitDepth: Int?
+    @Published var isAtmosActive = false // Music is playing lossy Atmos/Spatial, not Lossless
     @Published var enableBitDepthDetection = Defaults.shared.userPreferBitDepthDetection
     
     private var enableBitDepthDetectionCancellable: AnyCancellable?
@@ -142,6 +143,12 @@ class OutputDevices: ObservableObject {
 //            else {
 //                allStats.append(contentsOf: CMPlayerParser.parseCoreMediaConsoleLogs(coreMediaLogs))
 //            }
+
+            // Flag lossy Dolby Atmos / Spatial playback (no lossless stream to switch to).
+            // nil means no decode info in this window, so keep the previous value.
+            if let atmos = CMPlayerParser.detectAtmos(coreAudioLogs) {
+                DispatchQueue.main.async { self.isAtmosActive = atmos }
+            }
 
 //            allStats.sort(by: {$0.priority > $1.priority})
             print("[getAllStats] \(allStats)")


### PR DESCRIPTION
## What & why

When Spatial Audio / Dolby Atmos is enabled, Music plays the lossy AAC asset (decoded via `ACMP4AACBaseDecoder` @ 48 kHz) and never touches the Apple Lossless decoder. The parser only reads sample rates from `ACAppleLosslessDecoder` lines, so in this state it finds nothing to switch to and the output device silently stays at whatever rate it was — which looks like the app is "stuck."

This adds a positive detector for that state and a small red warning row in the menu so users understand *why* switching isn't happening.

## How

- `CMPlayerParser.detectAtmos(_:)` classifies the current CoreAudio log window:
  - `alac` decoder present → Lossless (`false`)
  - `aac` decoder @ 48 kHz with no `alac` → Atmos / Spatial (`true`)
  - neither (no decode info in window) → `nil`, so callers keep the previous value instead of flip-flopping during steady playback
- `OutputDevices.isAtmosActive` — published flag, set inside the existing detection loop (reuses the logs already fetched; no extra log queries).
- `MenuView` — red "⚠️ Dolby Atmos is on — not playing in Lossless" row shown while active.

## Not a toggle (re: #91)

#91 asked for an on/off toggle. Apple doesn't expose the Atmos / Spatial setting to third-party apps, so a real toggle isn't possible from here. This makes the state *visible* instead — so it's obvious why the rate isn't switching, rather than leaving users guessing.

## Testing

Built and run on macOS 26.5 (Tahoe), Native Instruments Komplete Audio 6:

- Lossless track → no warning, switches to 88.2 kHz as normal (`isAtmosActive = false`)
- Dolby Atmos "Always On" + Atmos track → red warning row appears (`isAtmosActive = true`); confirmed against ground-truth system logs showing the AAC / 48 kHz decode path with no `alac`
- Atmos off again → warning clears on the next track change

Detection is log-based, consistent with the existing approach in the app. Diff is 3 files / ~45 lines. Happy to adjust wording, placement, or rework this against the v3 branch (#201) if you'd prefer.
